### PR TITLE
Correct BlobEvent constructor

### DIFF
--- a/MediaRecorder.html
+++ b/MediaRecorder.html
@@ -273,15 +273,14 @@ behavior specified in this document. </p>
 
 <section id="blob-event">
     <h2>Blob Event</h2>
-    <dl title='[Constructor(DOMString type, optional BlobEventInit eventInit)] interface BlobEvent : Event' class='idl'>
-        <dd>                   
-            <dl class='parameters'>
+    <dl title='interface BlobEvent : Event' class='idl'>
+        <dt>[Constructor(DOMString type, optional BlobEventInit eventInit)]</dt>
+            <dd><dl class='parameters'>
                 <dt>DomString type</dt>
                 <dd>Associated <a href=https://dom.spec.whatwg.org/#interface-event>Event type.</a></dd>
                 <dt>BlobEventInit eventInit</dt>
                 <dd>An initializer whose <code>data</code> field will be used to initialize the attribute of the same name.</dd>
-            </dl>
-        </dd>
+        </dl></dd>
         <dt>readonly attribute Blob data</dt>
         <dd>Returns a Blob object whose type attribute indicates the encoding of the blob data.</dd>
     </dl>

--- a/MediaRecorder.html
+++ b/MediaRecorder.html
@@ -274,11 +274,11 @@ behavior specified in this document. </p>
 <section id="blob-event">
     <h2>Blob Event</h2>
     <dl title='interface BlobEvent : Event' class='idl'>
-        <dt>[Constructor(DOMString type, optional BlobEventInit eventInit)]</dt>
+        <dt>Constructor(DOMString type, optional BlobEventInit eventInit)</dt>
             <dd><dl class='parameters'>
                 <dt>DomString type</dt>
                 <dd>Associated <a href=https://dom.spec.whatwg.org/#interface-event>Event type.</a></dd>
-                <dt>BlobEventInit eventInit</dt>
+                <dt>optional BlobEventInit eventInit</dt>
                 <dd>An initializer whose <code>data</code> field will be used to initialize the attribute of the same name.</dd>
         </dl></dd>
         <dt>readonly attribute Blob data</dt>

--- a/MediaRecorder.html
+++ b/MediaRecorder.html
@@ -272,23 +272,26 @@ behavior specified in this document. </p>
 </section>
 
 <section id="blob-event">
-        <h2>Blob Event</h2>
+    <h2>Blob Event</h2>
+    <dl title='[Constructor(DOMString type, optional BlobEventInit eventInit)] interface BlobEvent : Event' class='idl'>
+        <dd>                   
+            <dl class='parameters'>
+                <dt>DomString type</dt>
+                <dd>Associated <a href=https://dom.spec.whatwg.org/#interface-event>Event type.</a></dd>
+                <dt>BlobEventInit eventInit</dt>
+                <dd>An initializer whose <code>data</code> field will be used to initialize the attribute of the same name.</dd>
+            </dl>
+        </dd>
+        <dt>readonly attribute Blob data</dt>
+        <dd>Returns a Blob object whose type attribute indicates the encoding of the blob data.</dd>
+    </dl>
 
-        <dl title='[Constructor] interface BlobEvent : Event' class='idl'>
-  <dt>readonly attribute Blob data</dt>
-  <dd>
-    Returns a Blob object whose type attribute indicates the encoding of the blob data.
-  </dd>
-</dl>
 
-
-        <h3>BlobEventInit</h3>
-  <dl title='dictionary BlobEventInit' class='idl'>
-          <dt>Blob data</dt>
-          <dd>
-            A Blob object containing the data to deliver via this event.
-          </dd>
-        </dl>
+    <h3>BlobEventInit</h3>
+    <dl title='dictionary BlobEventInit' class='idl'>
+        <dt>Blob data</dt>
+        <dd>A Blob object containing the data to deliver via this event.</dd>
+    </dl>
 </section>
 
 <section id="properties">


### PR DESCRIPTION
BlobEvent does not mention the |type| or BlobEventInit constructor parameters. This pull adds those and their descriptions.

Addresses issue https://github.com/w3c/mediacapture-record/issues/11.
Implemented by Gecko [1] and Chromium [2] in this way, to the best of my knowledge.

[1] https://github.com/mozilla/gecko-dev/blob/master/dom/webidl/BlobEvent.webidl
[2] https://code.google.com/p/chromium/codesearch#chromium/src/third_party/WebKit/Source/modules/mediarecorder/BlobEvent.idl&q=blobevent%20idl&sq=package:chromium&type=cs
