### PR TITLE
s/DOMString canRecordMimeType()/bool isTypeSupported()/

### DIFF
--- a/MediaRecorder.html
+++ b/MediaRecorder.html
@@ -149,14 +149,14 @@
     </dd>
 
     <dt>static bool isTypeSupported(DOMString type)</dt>
-    <dd> Check to see whether a <code>MediaRecorder</code> can record in the specified Mime type. If true is returned from this method, it only indicates that the <code>MediaRecorder</code> implementation is capable of recording Blob objects for the specified MIME type. Recording may still fail if sufficient resources are not available to support the concrete media encoding. When this method is invoked, the user agent must run the following steps:
+    <dd> Check to see whether a <code>MediaRecorder</code> can record in the specified Mime type. If true is returned from this method, it only indicates that the <code>MediaRecorder</code> implementation is capable of recording Blob objects for the specified MIME type. Recording may still fail if sufficient resources are not available to support the concrete media encoding. When this method is invoked, the User Agent must run the following steps:
      <ol class="method-algorithm">
       <li>If <code>type</code> is an empty string, then return false.</li>
       <li>If <code>type</code> does not contain a valid MIME type string, then return false.</li>
-      <li>If <code>type</code> contains a media type or media subtype that the MediaSource does not support, then return false.</li>
+      <li>If <code>type</code> contains a media type or media subtype that the MediaRecorder does not support, then return false.</li>
       <li>If <code>type</code> contains a media container that the MediaSource does not support, then return false.</li>
       <li>If <code>type</code> contains a codec that the MediaSource does not support, then return false.</li>
-      <li>If the MediaSource does not support the specified combination of media type, media subtype, and codecs then return false.</li>
+      <li>If the MediaRecorder does not support the specified combination of media type/subtype, codecs and container then return false.</li>
       <li>Return true.</li>
      </ol>
 

--- a/MediaRecorder.html
+++ b/MediaRecorder.html
@@ -148,12 +148,21 @@
      </ol>
     </dd>
 
-    <dt>static DOMString canRecordMimeType(DOMString mimeType)</dt>
-    <dd><p>This method <em title="must" class="rfc2119">must</em> return the empty string if <code>mimeType</code> is a type that the user agent knows it cannot record; it <em title="must" class="rfc2119">must</em> return "probably" if the user agent is confident that <code>mimeType</code> represents a type that it can record; and it <em title="must" class="rfc2119">must</em> return "maybe" otherwise. Implementors are encouraged to return "maybe" unless the type can be confidently established as being supported or not.</p>
+    <dt>static bool isTypeSupported(DOMString type)</dt>
+    <dd> Check to see whether a <code>MediaRecorder</code> can record in the specified Mime type. If true is returned from this method, it only indicates that the <code>MediaRecorder</code> implementation is capable of recording Blob objects for the specified MIME type. Recording may still fail if sufficient resources are not available to support the concrete media encoding. When this method is invoked, the user agent must run the following steps:
+     <ol class="method-algorithm">
+      <li>If <code>type</code> is an empty string, then return false.</li>
+      <li>If <code>type</code> does not contain a valid MIME type string, then return false.</li>
+      <li>If <code>type</code> contains a media type or media subtype that the MediaSource does not support, then return false.</li>
+      <li>If <code>type</code> contains a media container that the MediaSource does not support, then return false.</li>
+      <li>If <code>type</code> contains a codec that the MediaSource does not support, then return false.</li>
+      <li>If the MediaSource does not support the specified combination of media type, media subtype, and codecs then return false.</li>
+      <li>Return true.</li>
+     </ol>
 
-     <dl class='parameters'>
-      <dt>DOMString mimeType</dt>
-      <dd>A MimeType, including parameters, specifying a container format for recording.</dd>
+     <dl class="parameters">
+      <dt>DOMString type</dt>
+      <dd>A <a href="https://tools.ietf.org/html/rfc2046">Mime Type</a>, including parameters, specifying a container and/or codec formats for recording.</dd>
      </dl>
     </dd>
   </dl>


### PR DESCRIPTION
This patch proposes changing the signature of 
static DOMString canRecordMimeType(DOMString type)
with
static bool isTypeSupported(DOMString type)

in relation to issue https://github.com/w3c/mediacapture-record/issues/10. The wording is strongly inspired by [`MediaSource.isTypeSupported()`](https://w3c.github.io/media-source/#widl-MediaSource-isTypeSupported-boolean-DOMString-type) as proposed in the said issue. 

Note that this change is low risk: Gecko does not implement a static type checker [1] to the best of my knowledge and Blink implementation has only recently landed in Stable, and the use of this static method is minor, so now's the time to update it.

[1] https://github.com/mozilla/gecko-dev/blob/master/dom/webidl/MediaRecorder.webidl
