### PR TITLE
Changed constructor mimeType with a MediaRecorderOptions dictionary

### DIFF
--- a/MediaRecorder.html
+++ b/MediaRecorder.html
@@ -43,15 +43,15 @@
 
  <section id="MediaRecorderAPI"><h2>Media Recorder API</h2>
    <dl title='interface MediaRecorder : EventTarget' class="idl">
-    <dt>Constructor(MediaStream stream, optional DOMString mimeType)</dt>
+    <dt>Constructor(MediaStream stream, optional MediaRecorderOptions options)</dt>
     <dd>
      <dl class='parameters'>
       <dt>MediaStream stream</dt>
       <dd>The MediaStream to be recorded.  This will be the value of the <code>stream</code> attribute. See [[!GETUSERMEDIA]] for the definition of MediaStream.</dd>
 
-      <dt>optional DOMString mimeType</dt>
-      <dd>The container format for the recording, which may include any parameters that are defined for the format.  If the UA does not support the format or any of the parameters specified, it <em title="must" class="rfc2119"> must </em> throw an <code>NotSupportedError</code> DOMException. If this paramater is not specified, the UA will use a platform-specific default format.  The container format, whether passed in to the constructor or defaulted, will be used as the value of the <code>mimeType</code> attribute.
-      </dd>
+      <dt>optional MediaRecorderOptions options</dt>
+      <dd>A dictionary of options to for the UA instructing how the recording will take part. <code>options.mimeType</code>, if present, will become the value of <code>mimeType</code> attribute.</dd>
+
      </dl>
     </dd>
 
@@ -157,6 +157,20 @@
      </dl>
     </dd>
   </dl>
+
+  <section id="MediaRecorderOptions"><h3>MediaRecorderOptions</h3>
+   <dl class="idl" title="dictionary MediaRecorderOptions">
+    <dt>DOMString mimeType = ""</dt>
+    <dd>The container and codec(s) format(s) for the recording, which may include any parameters that are defined for the format.  If the UA does not support the format or any of the parameters specified, it <em title="must" class="rfc2119"> must </em> throw an <code>NotSupportedError</code> DOMException. If this paramater is not specified, the UA will use a platform-specific default format.  The container format, whether passed in to the constructor or defaulted, will be used as the value of the <code>mimeType</code> attribute.
+    </dd>
+    <dt>unsigned long audioBitsPerSecond</dt>
+    <dd>Aggregate target bits per second for encoding of the Audio track(s), if any. This is a hint for the encoder and the value might only be achieved over a long time.</dd>
+    <dt>unsigned long videoBitsPerSecond</dt>
+    <dd>Aggregate target bits per second for encoding of the Video track(s), if any. This is a hint for the encoder and the value might be surpassed or not achieved.</dd>
+    <dt>unsigned long bitsPerSecond</dt>
+    <dd>Aggregate target bits per second for encoding of all Video and Audio Track(s) present. This parameter overrides either <code>audioBitsPerSecond</code> or <code>videoBitsPerSecond</code> if present, and might be distributed among the present track encoders as the UA sees fit. This parameter is a hint for the encoder(s) and the total value might be surpassed or not achieved at all.</dd>
+   </dl>
+  </section>
 
   <section id="RecordingState"><h3>RecordingState</h3>
    <dl title="enum RecordingState" class="idl">


### PR DESCRIPTION
This is a first go at changing the constructor argument |mimeType| with a dictionary of Options, re https://github.com/w3c/mediacapture-record/issues/19. 

As mentioned in this issue, this patch is basically taking in [Gecko implementation](https://github.com/mozilla/gecko-dev/blob/master/dom/webidl/MediaRecorder.webidl#L52), and Blink has a [CL](https://codereview.chromium.org/1507183002/) ready to update to it.
