### PR TITLE
corrected: |required| goes to BlobEventInit.data

### DIFF
--- a/MediaRecorder.html
+++ b/MediaRecorder.html
@@ -182,11 +182,11 @@
 <section id="blob-event">
     <h2>Blob Event</h2>
     <dl title='interface BlobEvent : Event' class='idl'>
-        <dt>Constructor(DOMString type, required BlobEventInit eventInitDict)</dt>
+        <dt>Constructor(DOMString type, BlobEventInit eventInitDict)</dt>
             <dd><dl class='parameters'>
                 <dt>DOMString type</dt>
                 <dd>Associated <a href=https://dom.spec.whatwg.org/#interface-event>Event type.</a></dd>
-                <dt>required BlobEventInit eventInitDict</dt>
+                <dt>BlobEventInit eventInitDict</dt>
                 <dd>An initializer whose <code>data</code> field will be used to initialize the attribute of the same name.</dd>
         </dl></dd>
         <dt>readonly attribute Blob data</dt>
@@ -196,7 +196,7 @@
 
     <h3>BlobEventInit</h3>
     <dl title='dictionary BlobEventInit' class='idl'>
-        <dt>Blob data</dt>
+        <dt>required Blob data</dt>
         <dd>A Blob object containing the data to deliver via this event.</dd>
     </dl>
 </section>


### PR DESCRIPTION
Re. comment in https://github.com/w3c/mediacapture-record/pull/38/files#r47154100
