### PR TITLE
mimeType does not need a default value; isTypeSupported("") should return true

### DIFF
--- a/MediaRecorder.html
+++ b/MediaRecorder.html
@@ -151,7 +151,7 @@
     <dt>static bool isTypeSupported(DOMString type)</dt>
     <dd> Check to see whether a <code>MediaRecorder</code> can record in the specified Mime type. If true is returned from this method, it only indicates that the <code>MediaRecorder</code> implementation is capable of recording Blob objects for the specified MIME type. Recording may still fail if sufficient resources are not available to support the concrete media encoding. When this method is invoked, the User Agent must run the following steps:
      <ol class="method-algorithm">
-      <li>If <code>type</code> is an empty string, then return false.</li>
+      <li>If <code>type</code> is an empty string, then return true (note that this case is essentially equivalent to leaving up to the UA the choice of container and codecs on constructor).</li>
       <li>If <code>type</code> does not contain a valid MIME type string, then return false.</li>
       <li>If <code>type</code> contains a media type or media subtype that the MediaRecorder does not support, then return false.</li>
       <li>If <code>type</code> contains a media container that the MediaSource does not support, then return false.</li>
@@ -169,7 +169,7 @@
 
   <section id="MediaRecorderOptions"><h3>MediaRecorderOptions</h3>
    <dl class="idl" title="dictionary MediaRecorderOptions">
-    <dt>DOMString mimeType = ""</dt>
+    <dt>DOMString mimeType</dt>
     <dd>The container and codec(s) format(s) for the recording, which may include any parameters that are defined for the format.  If the UA does not support the format or any of the parameters specified, it <em title="must" class="rfc2119"> must </em> throw an <code>NotSupportedError</code> DOMException. If this paramater is not specified, the UA will use a platform-specific default format.  The container format, whether passed in to the constructor or defaulted, will be used as the value of the <code>mimeType</code> attribute.
     </dd>
     <dt>unsigned long audioBitsPerSecond</dt>

--- a/MediaRecorder.html
+++ b/MediaRecorder.html
@@ -302,11 +302,6 @@
           <td> An operation was called on an object on which it is not allowed or at a time when it is not allowed, or if a request is made on a source object that has been deleted or removed. </td>
         </tr>
         <tr>
-          <td><code>UnknownError</code></td>
-          <td>The operation failed for an unknown transient reason (e.g. out of memory), or a modification to the <code>stream</code> has occurred that makes it impossible to continue recording (e.g. a Track has been added while recording is occurring). User agents should provide as much additional information as possible in the <code>message</code> attribute.
-          </td>
-        </tr>
-        <tr>
           <td><code>NotSupportedError</code></td>
           <td>A <a class="idlType" href="#idl-def-MediaRecorder"><code>MediaRecorder</code></a> could not be created due to unsupported options (e.g. mime type) specification. User agents should provide as much additional information  as possible in the <code>message</code> attribute.</td>
         </tr>
@@ -355,7 +350,7 @@
         <tr>
           <td><dfn id="event-mediarecorder-ErrorEvent"><code>ErrorEvent</code></dfn></td>
           <td><a><code>EventError</code></a></td>
-          <td>A fatal error has occurred and the UA has stopped recording. More detailed error information is available in the 'message' attribute. </td>
+          <td>An error has occurred, e.g. out of memory or a modification to the <code>stream</code> has occurred (e.g. a Track has been added to or removed from the said <code>stream</code> while recording is occurring). </td>
         </tr>
       </tbody>
     </table>


### PR DESCRIPTION
Two things:
- removing the "" part of mimeType in the options dictionary since the dictionary itself is optional, see discussion in the issue https://github.com/w3c/mediacapture-record/issues/40
- isTypeSupported() should return `true` when called with an empty MIME type, to line up with the constructor version of MIME, where an empty string means that the UA can freely choose whichever codecs might be most appropriate. (This lines up w/ Blink, Gecko does not implement this function). This is also related to https://github.com/w3c/mediacapture-record/issues/40.
