### PR TITLE
Produce data encoded so far when MS isolation properties change (#97)

### DIFF
--- a/MediaRecorder.html
+++ b/MediaRecorder.html
@@ -234,9 +234,9 @@
 
                   <li>If at any point the stream's isolation properties change
                   so that MediaRecorder is no longer allowed access to it, the
-                  UA MUST immediately stop gathering data, discard any data that
-                  it has gathered, and queue a task, using the DOM manipulation
-                  task source, that runs the following steps:
+                  UA MUST immediately stop gathering data, and queue a task,
+                  using the DOM manipulation task source, that runs the
+                  following steps:
                   <ol>
                     <li>Set <a>state</a> to
                     <a href="#dom-recordingstate-inactive">inactive</a>.</li>
@@ -244,6 +244,9 @@
                     error event</a> named <code>SecurityError</code> at
                     <var>target</var>.
                     </li>
+                    <li><a href="#dfn-to-fire-a-blob-event">Fire a blob event</a>
+                    named <code>dataavailable</code> at <var>target</var> with
+                    <var>blob</var>.</li>
                     <li><a href="https://dom.spec.whatwg.org/#concept-event-fire">
                     Fire an event</a> named <code>stop</code> at
                     <var>target</var>.</li>


### PR DESCRIPTION
This homogenises the wording with the subsequent point that details what to do when recording can't continue for reasons other than isolation. In both cases: stop gathering data, fire an error event, send whatever has been encoded and fire an event called stop.