### PR TITLE
Make Error Event go after ondataavailable.

### DIFF
--- a/MediaRecorder.bs
+++ b/MediaRecorder.bs
@@ -286,7 +286,7 @@ interface MediaRecorder : EventTarget {
         <td class="prmNullFalse"><span role="img" aria-label="False">&#10008;</span></td>
         <td class="prmOptTrue"><span role="img" aria-label="True">&#10004;</span></td>
         <td class="prmDesc">The minimum number of milliseconds of data
-        to return in a single Blob.</td>
+        to return in a single {{Blob}}.</td>
       </tr>
     </tbody>
   </table>
@@ -302,7 +302,7 @@ interface MediaRecorder : EventTarget {
     task, using the DOM manipulation task source, that runs the following steps:
     <ol>
       <li>Set {{state}} to {{inactive}} and stop gathering data.</li>
-      <li>Let <var>blob</var> be the Blob of collected data so far and
+      <li>Let <var>blob</var> be the {{Blob}} of collected data so far and
       let <var>target</var> be the MediaRecorder context object, then
       <a href="#to-fire-a-blob-event">fire a blob event</a> named
       <a>dataavailable</a> at <var>target</var> with <var>blob</var>.</li>
@@ -369,7 +369,7 @@ interface MediaRecorder : EventTarget {
       (Note that <var>blob</var> will be empty if no data has been gathered
       yet.)</li>
 
-      <li>Create a new Blob and gather subsequent data into it.</li>
+      <li>Create a new {{Blob}} and gather subsequent data into it.</li>
     </ol>
     </li>
     <li>return <code>undefined</code>.</li>
@@ -570,31 +570,28 @@ dictionary BlobEventInit {
 
 ## General principles ## {#error-handling-principles}
 
-If at any moment the UA finds an error condition, the UA MUST run the following
-steps:
-  <ol>
-    <li>If {{state}} is {{inactive}} throw an {{InvalidStateError}}
-    {{DOMException}} and terminate these steps. Otherwise the UA MUST queue a
-    task, using the DOM manipulation task source, that runs the following steps:
-    <ol>
-      <li>Set {{state}} to {{inactive}} and stop gathering data.</li>
-      <li>Let <var>blob</var> be the {{Blob}} of collected data so far and
-      let <var>target</var> be the MediaRecorder context object</li>
+If at any moment the UA finds an error condition, the UA MUST queue a task,
+using the DOM manipulation task source, that runs the following steps:
+<ol>
+  <li>Set {{state}} to {{inactive}} and stop gathering data.</li>
 
-      <li><a href="#to-fire-a-blob-event">Fire a blob event</a> named
-        <a>dataavailable</a> at <var>target</var> with <var>blob</var>.</li>
-      <li><a>Fire an event</a> named <a>stop</a> at <var>target</var></li>
-      <li><a>Fire an error event</a> named {{MediaRecorderErrorEvent}} at
-        <var>target</var>.</li>
-    </ol>
-  </li>
+  <li>Let <var>blob</var> be the {{Blob}} of collected data so far and
+  let <var>target</var> be the MediaRecorder context object</li>
+
+  <li><a href="#to-fire-a-blob-event">Fire a blob event</a> named
+  <a>dataavailable</a> at <var>target</var> with <var>blob</var>.</li>
+
+  <li><a>Fire an event</a> named <a>stop</a> at <var>target</var></li>
+
+  <li><a>Fire an error event</a> named <var>event</var> at
+  <var>target</var>.</li>
 </ol>
 
 <div class="note">
-  The UA may set platform-specific limits, such as those for the minimum and
-  maximum {{Blob}} size that it will support, or the number of
-  {{MediaStreamTrack}}s it will record at once. It will signal a fatal error if
-  these limits are exceeded.
+  The UA MAY set platform-specific limits, e.g. for the minimum and maximum
+  {{Blob}} size that it will support, or the number of {{MediaStreamTrack}}s it
+  will record at once. It will signal a fatal error if these limits are
+  exceeded.
 </div>
 
 ## MediaRecorderErrorEvent ## {#errorevent-section}

--- a/MediaRecorder.bs
+++ b/MediaRecorder.bs
@@ -569,20 +569,33 @@ dictionary BlobEventInit {
 # Error handling # {#error-handling}
 
 ## General principles ## {#error-handling-principles}
-<em>This section is non-normative.</em>
 
-The UA will throw a {{DOMException}} when the error can be detected at the time
-that the call is made. In all other cases the UA will <a>fire an event</a> named
-{{MediaRecorderErrorEvent}}.  If recording has been started and not yet stopped
-when the error occurs, let <var>blob</var> be the {{Blob}} of collected data so
-far; before raising the error, the UA will <a href="#to-fire-a-blob-event">fire a
-dataavailable event</a> with <var>blob</var>; then the UA will
-<a>fire an event</a> named <code>stop</code>; finally the UA will
-<a>fire an error event</a>.
-The UA may set platform-specific limits, such as those for the minimum and
-maximum {{Blob}} size that it will support, or the number of
-{{MediaStreamTrack}}s it will record at once.
-It will signal a fatal error if these limits are exceeded.
+If at any moment the UA finds an error condition, the UA MUST run the following
+steps:
+  <ol>
+    <li>If {{state}} is {{inactive}} throw an {{InvalidStateError}}
+    {{DOMException}} and terminate these steps. Otherwise the UA MUST queue a
+    task, using the DOM manipulation task source, that runs the following steps:
+    <ol>
+      <li>Set {{state}} to {{inactive}} and stop gathering data.</li>
+      <li>Let <var>blob</var> be the {{Blob}} of collected data so far and
+      let <var>target</var> be the MediaRecorder context object</li>
+
+      <li><a href="#to-fire-a-blob-event">Fire a blob event</a> named
+        <a>dataavailable</a> at <var>target</var> with <var>blob</var>.</li>
+      <li><a>Fire an event</a> named <a>stop</a> at <var>target</var></li>
+      <li><a>Fire an error event</a> named {{MediaRecorderErrorEvent}} at
+        <var>target</var>.</li>
+    </ol>
+  </li>
+</ol>
+
+<div class="note">
+  The UA may set platform-specific limits, such as those for the minimum and
+  maximum {{Blob}} size that it will support, or the number of
+  {{MediaStreamTrack}}s it will record at once. It will signal a fatal error if
+  these limits are exceeded.
+</div>
 
 ## MediaRecorderErrorEvent ## {#errorevent-section}
 

--- a/MediaRecorder.bs
+++ b/MediaRecorder.bs
@@ -208,8 +208,8 @@ interface MediaRecorder : EventTarget {
       runs the following steps:
       <ol>
         <li>Set {{state}} to {{inactive}}.</li>
-        <li><a>Fire an error event</a> named {{SecurityError}} at
-        <var>target</var>.</li>
+        <li><a>Fire an error event</a> named <a>error</a> with a
+        {{SecurityError}} at <var>target</var>.</li>
         <li><a href="#to-fire-a-blob-event">Fire a blob event</a> named
         <a>dataavailable</a> at <var>target</var> with <var>blob</var>.</li>
         <li><a>Fire an event</a> named <a>stop</a> at <var>target</var>.</li>
@@ -222,8 +222,8 @@ interface MediaRecorder : EventTarget {
       following steps:
       <ol>
         <li>Set {{state}} to {{inactive}}.</li>
-        <li><a>Fire an error event</a> named {{UnknownError}} at
-        <var>target</var>.</li>
+        <li><a>Fire an error event</a> named <a>error</a> with an
+        {{UnknownError}} at <var>target</var>.</li>
         <li><a href="#to-fire-a-blob-event">Fire a blob event</a> named
         <a>dataavailable</a> at <var>target</var> with <var>blob</var>.</li>
         <li><a>Fire an event</a> named <a>stop</a> at <var>target</var>.</li>
@@ -583,8 +583,8 @@ using the DOM manipulation task source, that runs the following steps:
 
   <li><a>Fire an event</a> named <a>stop</a> at <var>target</var></li>
 
-  <li><a>Fire an error event</a> named {{UnknownError}} at <var>target</var>.
-  </li>
+  <li><a>Fire an error event</a> named <a>error</a> with an {{UnknownError}} at
+   <var>target</var>.</li>
 </ol>
 
 <div class="note">

--- a/MediaRecorder.bs
+++ b/MediaRecorder.bs
@@ -583,8 +583,8 @@ using the DOM manipulation task source, that runs the following steps:
 
   <li><a>Fire an event</a> named <a>stop</a> at <var>target</var></li>
 
-  <li><a>Fire an error event</a> named <var>event</var> at
-  <var>target</var>.</li>
+  <li><a>Fire an error event</a> named {{UnknownError}} at <var>target</var>.
+  </li>
 </ol>
 
 <div class="note">

--- a/MediaRecorder.bs
+++ b/MediaRecorder.bs
@@ -575,9 +575,10 @@ The UA will throw a {{DOMException}} when the error can be detected at the time
 that the call is made. In all other cases the UA will <a>fire an event</a> named
 {{MediaRecorderErrorEvent}}.  If recording has been started and not yet stopped
 when the error occurs, let <var>blob</var> be the {{Blob}} of collected data so
-far; after raising the error, the UA will <a href="#to-fire-a-blob-event">fire a
-dataavailable event</a> with <var>blob</var>; immediately after the UA will then
-<a>fire an event</a> named <code>stop</code>.
+far; before raising the error, the UA will <a href="#to-fire-a-blob-event">fire a
+dataavailable event</a> with <var>blob</var>; then the UA will
+<a>fire an event</a> named <code>stop</code>; finally the UA will
+<a>fire an event</a> named <code>error</code>.
 The UA may set platform-specific limits, such as those for the minimum and
 maximum {{Blob}} size that it will support, or the number of
 {{MediaStreamTrack}}s it will record at once.

--- a/MediaRecorder.bs
+++ b/MediaRecorder.bs
@@ -578,7 +578,7 @@ when the error occurs, let <var>blob</var> be the {{Blob}} of collected data so
 far; before raising the error, the UA will <a href="#to-fire-a-blob-event">fire a
 dataavailable event</a> with <var>blob</var>; then the UA will
 <a>fire an event</a> named <code>stop</code>; finally the UA will
-<a>fire an event</a> named <code>error</code>.
+<a>fire an error event</a>.
 The UA may set platform-specific limits, such as those for the minimum and
 maximum {{Blob}} size that it will support, or the number of
 {{MediaStreamTrack}}s it will record at once.

--- a/MediaRecorder.html
+++ b/MediaRecorder.html
@@ -419,7 +419,7 @@
 	[data-algorithm]:not(.heading) {
 	  padding: .5em;
 	  border: thin solid #ddd; border-radius: .5em;
-	  margin: .5em 0;
+	  margin: .5em calc(-0.5em - 1px);
 	}
 	[data-algorithm]:not(.heading) > :first-child {
 	  margin-top: 0;
@@ -1183,7 +1183,7 @@ Possible extra rowspan handling
       background-attachment: fixed;
     }
   </style>
-  <meta content="Bikeshed version 176d39d5a285c04f57d2f0e078fa69273028eb45" name="generator">
+  <meta content="Bikeshed version 108b329dea0b65829ab3050d2b667fd8aa4dc7c1" name="generator">
 <style>
 table {
   border-collapse: collapse;
@@ -1447,7 +1447,7 @@ pre.idl.highlight { color: #708090; }
   <div class="head">
    <p data-fill-with="logo"><a class="logo" href="http://www.w3.org/"> <img alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2016/logos/W3C" width="72"> </a> </p>
    <h1 class="p-name no-ref" id="title">MediaStream Recording</h1>
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2017-01-11">11 January 2017</time></span></h2>
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2017-02-14">14 February 2017</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -1965,8 +1965,8 @@ its <code class="idl"><a data-link-type="idl" href="#dom-blobevent-data" id="ref
    <p>The UA will throw a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code> when the error can be detected at the time
 that the call is made. In all other cases the UA will <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-event-fire">fire an event</a> named <code class="idl"><a data-link-type="idl" href="#mediarecordererrorevent" id="ref-for-mediarecordererrorevent-2">MediaRecorderErrorEvent</a></code>.  If recording has been started and not yet stopped
 when the error occurs, let <var>blob</var> be the <code class="idl"><a data-link-type="idl" href="https://w3c.github.io/FileAPI/#dfn-Blob">Blob</a></code> of collected data so
-far; after raising the error, the UA will <a href="#to-fire-a-blob-event" id="ref-for-to-fire-a-blob-event-7">fire a
-dataavailable event</a> with <var>blob</var>; immediately after the UA will then <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-event-fire">fire an event</a> named <code>stop</code>.
+far; before raising the error, the UA will <a href="#to-fire-a-blob-event" id="ref-for-to-fire-a-blob-event-7">fire a
+dataavailable event</a> with <var>blob</var>; then the UA will <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-event-fire">fire an event</a> named <code>stop</code>; finally the UA will <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-event-fire">fire an event</a> named <code>error</code>.
 The UA may set platform-specific limits, such as those for the minimum and
 maximum <code class="idl"><a data-link-type="idl" href="https://w3c.github.io/FileAPI/#dfn-Blob">Blob</a></code> size that it will support, or the number of <code class="idl"><a data-link-type="idl" href="https://www.w3.org/TR/mediacapture-streams/#mediastreamtrack">MediaStreamTrack</a></code>s it will record at once.
 It will signal a fatal error if these limits are exceeded.</p>
@@ -2110,7 +2110,7 @@ specific type.</p>
                       <span class="s2">"audio/webm"</span><span class="p">,</span>
                       <span class="s2">"video/mp4;codecs=avc1"</span><span class="p">,</span>
                       <span class="s2">"video/invalid"</span><span class="p">]</span><span class="p">;</span>
-  contentTypes<span class="p">.</span>forEach<span class="p">(</span>contentType <span class="o">=></span> <span class="p">{</span>
+  contentTypes<span class="p">.</span>forEach<span class="p">(</span>contentType <span class="p">=></span> <span class="p">{</span>
     console<span class="p">.</span>log<span class="p">(</span>contentType <span class="o">+</span> <span class="s1">' is '</span>
         <span class="o">+</span> <span class="p">(</span>MediaRecorder<span class="p">.</span>isTypeSupported<span class="p">(</span>contentType<span class="p">)</span> <span class="o">?</span>
             <span class="s1">'supported'</span> <span class="o">:</span> <span class="s1">'NOT supported '</span><span class="p">)</span><span class="p">)</span><span class="p">;</span>
@@ -2139,7 +2139,7 @@ specific type.</p>
       <span class="k">return</span><span class="p">;</span>
     <span class="p">}</span>
 
-    recorder<span class="p">.</span>ondataavailable <span class="o">=</span> <span class="p">(</span>event<span class="p">)</span> <span class="o">=></span> <span class="p">{</span>
+    recorder<span class="p">.</span>ondataavailable <span class="o">=</span> <span class="p">(</span>event<span class="p">)</span> <span class="p">=></span> <span class="p">{</span>
       console<span class="p">.</span>log<span class="p">(</span><span class="s1">' Recorded chunk of size '</span> <span class="o">+</span> event<span class="p">.</span>data<span class="p">.</span>size <span class="o">+</span> <span class="s2">"B"</span><span class="p">)</span><span class="p">;</span>
       recordedChunks<span class="p">.</span>push<span class="p">(</span>event<span class="p">.</span>data<span class="p">)</span><span class="p">;</span>
     <span class="p">}</span><span class="p">;</span>
@@ -2149,7 +2149,7 @@ specific type.</p>
 
   navigator<span class="p">.</span>mediaDevices<span class="p">.</span>getUserMedia<span class="p">(</span><span class="p">{</span>video<span class="o">:</span> <span class="kc">true</span> <span class="p">,</span> audio<span class="o">:</span> <span class="kc">true</span><span class="p">}</span><span class="p">)</span>
       <span class="p">.</span>then<span class="p">(</span>gotMedia<span class="p">)</span>
-      <span class="p">.</span><span class="k">catch</span><span class="p">(</span>e <span class="o">=></span> <span class="p">{</span> console<span class="p">.</span>error<span class="p">(</span><span class="s1">'getUserMedia() failed: '</span> <span class="o">+</span> e<span class="p">)</span><span class="p">;</span> <span class="p">}</span><span class="p">)</span><span class="p">;</span>
+      <span class="p">.</span><span class="k">catch</span><span class="p">(</span>e <span class="p">=></span> <span class="p">{</span> console<span class="p">.</span>error<span class="p">(</span><span class="s1">'getUserMedia() failed: '</span> <span class="o">+</span> e<span class="p">)</span><span class="p">;</span> <span class="p">}</span><span class="p">)</span><span class="p">;</span>
 <span class="o">&lt;</span>/script>
 <span class="o">&lt;</span>/body>
 <span class="o">&lt;</span>/html>

--- a/MediaRecorder.html
+++ b/MediaRecorder.html
@@ -1183,7 +1183,7 @@ Possible extra rowspan handling
       background-attachment: fixed;
     }
   </style>
-  <meta content="Bikeshed version 108b329dea0b65829ab3050d2b667fd8aa4dc7c1" name="generator">
+  <meta content="Bikeshed version 70f542b3eb403344eee83c57e6631f734b1c4427" name="generator">
 <style>
 table {
   border-collapse: collapse;
@@ -1447,7 +1447,7 @@ pre.idl.highlight { color: #708090; }
   <div class="head">
    <p data-fill-with="logo"><a class="logo" href="http://www.w3.org/"> <img alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2016/logos/W3C" width="72"> </a> </p>
    <h1 class="p-name no-ref" id="title">MediaStream Recording</h1>
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2017-02-15">15 February 2017</time></span></h2>
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2017-02-16">16 February 2017</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -1698,7 +1698,7 @@ at regular intervals.</p>
       runs the following steps: 
          <ol>
           <li>Set <code class="idl"><a data-link-type="idl" href="#dom-mediarecorder-state" id="ref-for-dom-mediarecorder-state-4">state</a></code> to <code class="idl"><a data-link-type="idl" href="#dom-recordingstate-inactive" id="ref-for-dom-recordingstate-inactive-3">inactive</a></code>.
-          <li><a data-link-type="dfn" href="#fire-an-error-event" id="ref-for-fire-an-error-event-1">Fire an error event</a> named <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#securityerror">SecurityError</a></code> at <var>target</var>.
+          <li><a data-link-type="dfn" href="#fire-an-error-event" id="ref-for-fire-an-error-event-1">Fire an error event</a> named <a data-link-type="dfn" href="#error" id="ref-for-error-1">error</a> with a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#securityerror">SecurityError</a></code> at <var>target</var>.
           <li><a href="#to-fire-a-blob-event" id="ref-for-to-fire-a-blob-event-1">Fire a blob event</a> named <a data-link-type="dfn" href="#dataavailable" id="ref-for-dataavailable-2">dataavailable</a> at <var>target</var> with <var>blob</var>.
           <li><a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-event-fire">Fire an event</a> named <a data-link-type="dfn" href="#stop" id="ref-for-stop-2">stop</a> at <var>target</var>.
          </ol>
@@ -1709,7 +1709,7 @@ at regular intervals.</p>
       following steps: 
          <ol>
           <li>Set <code class="idl"><a data-link-type="idl" href="#dom-mediarecorder-state" id="ref-for-dom-mediarecorder-state-5">state</a></code> to <code class="idl"><a data-link-type="idl" href="#dom-recordingstate-inactive" id="ref-for-dom-recordingstate-inactive-4">inactive</a></code>.
-          <li><a data-link-type="dfn" href="#fire-an-error-event" id="ref-for-fire-an-error-event-2">Fire an error event</a> named <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#unknownerror">UnknownError</a></code> at <var>target</var>.
+          <li><a data-link-type="dfn" href="#fire-an-error-event" id="ref-for-fire-an-error-event-2">Fire an error event</a> named <a data-link-type="dfn" href="#error" id="ref-for-error-2">error</a> with an <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#unknownerror">UnknownError</a></code> at <var>target</var>.
           <li><a href="#to-fire-a-blob-event" id="ref-for-to-fire-a-blob-event-2">Fire a blob event</a> named <a data-link-type="dfn" href="#dataavailable" id="ref-for-dataavailable-3">dataavailable</a> at <var>target</var> with <var>blob</var>.
           <li><a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-event-fire">Fire an event</a> named <a data-link-type="dfn" href="#stop" id="ref-for-stop-3">stop</a> at <var>target</var>.
          </ol>
@@ -1969,7 +1969,7 @@ using the DOM manipulation task source, that runs the following steps:</p>
   let <var>target</var> be the MediaRecorder context object
     <li><a href="#to-fire-a-blob-event" id="ref-for-to-fire-a-blob-event-7">Fire a blob event</a> named <a data-link-type="dfn" href="#dataavailable" id="ref-for-dataavailable-8">dataavailable</a> at <var>target</var> with <var>blob</var>.
     <li><a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-event-fire">Fire an event</a> named <a data-link-type="dfn" href="#stop" id="ref-for-stop-6">stop</a> at <var>target</var>
-    <li><a data-link-type="dfn" href="#fire-an-error-event" id="ref-for-fire-an-error-event-3">Fire an error event</a> named <var>event</var> at <var>target</var>.
+    <li><a data-link-type="dfn" href="#fire-an-error-event" id="ref-for-fire-an-error-event-3">Fire an error event</a> named <a data-link-type="dfn" href="#error" id="ref-for-error-3">error</a> with an <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#unknownerror">UnknownError</a></code> at <var>target</var>.
    </ol>
    <div class="note" role="note"> The UA MAY set platform-specific limits, e.g. for the minimum and maximum <code class="idl"><a data-link-type="idl" href="https://w3c.github.io/FileAPI/#dfn-Blob">Blob</a></code> size that it will support, or the number of <code class="idl"><a data-link-type="idl" href="https://www.w3.org/TR/mediacapture-streams/#mediastreamtrack">MediaStreamTrack</a></code>s it
   will record at once. It will signal a fatal error if these limits are
@@ -2092,7 +2092,7 @@ specific type.</p>
       <td><code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#event">Event</a></code>
       <td>The UA has resumed recording data from the MediaStream.
      <tr>
-      <td><dfn data-dfn-type="dfn" data-noexport="" id="error">error<a class="self-link" href="#error"></a></dfn>
+      <td><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="error">error</dfn>
       <td><code class="idl"><a data-link-type="idl" href="#mediarecordererrorevent" id="ref-for-mediarecordererrorevent-5">MediaRecorderErrorEvent</a></code>
       <td>An error has occurred, e.g. out of memory or a modification to
       the <code class="idl"><a data-link-type="idl" href="#dom-mediarecorder-stream" id="ref-for-dom-mediarecorder-stream-7">stream</a></code> has occurred that makes it impossible to
@@ -2748,6 +2748,13 @@ the <code class="idl"><a data-link-type="idl" href="https://www.w3.org/TR/mediac
    <ul>
     <li><a href="#ref-for-resume-1">2.2. Attributes</a>
     <li><a href="#ref-for-resume-2">2.3. Methods</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="error">
+   <b><a href="#error">#error</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-error-1">2.3. Methods</a> <a href="#ref-for-error-2">(2)</a>
+    <li><a href="#ref-for-error-3">4.1. General principles</a>
    </ul>
   </aside>
 <script>/* script-dfn-panel */

--- a/MediaRecorder.html
+++ b/MediaRecorder.html
@@ -1447,7 +1447,7 @@ pre.idl.highlight { color: #708090; }
   <div class="head">
    <p data-fill-with="logo"><a class="logo" href="http://www.w3.org/"> <img alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2016/logos/W3C" width="72"> </a> </p>
    <h1 class="p-name no-ref" id="title">MediaStream Recording</h1>
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2017-02-14">14 February 2017</time></span></h2>
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2017-02-15">15 February 2017</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -1961,15 +1961,24 @@ its <code class="idl"><a data-link-type="idl" href="#dom-blobevent-data" id="ref
    </dl>
    <h2 class="heading settled" data-level="4" id="error-handling"><span class="secno">4. </span><span class="content">Error handling</span><a class="self-link" href="#error-handling"></a></h2>
    <h3 class="heading settled" data-level="4.1" id="error-handling-principles"><span class="secno">4.1. </span><span class="content">General principles</span><a class="self-link" href="#error-handling-principles"></a></h3>
-    <em>This section is non-normative.</em> 
-   <p>The UA will throw a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code> when the error can be detected at the time
-that the call is made. In all other cases the UA will <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-event-fire">fire an event</a> named <code class="idl"><a data-link-type="idl" href="#mediarecordererrorevent" id="ref-for-mediarecordererrorevent-2">MediaRecorderErrorEvent</a></code>.  If recording has been started and not yet stopped
-when the error occurs, let <var>blob</var> be the <code class="idl"><a data-link-type="idl" href="https://w3c.github.io/FileAPI/#dfn-Blob">Blob</a></code> of collected data so
-far; before raising the error, the UA will <a href="#to-fire-a-blob-event" id="ref-for-to-fire-a-blob-event-7">fire a
-dataavailable event</a> with <var>blob</var>; then the UA will <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-event-fire">fire an event</a> named <code>stop</code>; finally the UA will <a data-link-type="dfn" href="#fire-an-error-event" id="ref-for-fire-an-error-event-3">fire an error event</a>.
-The UA may set platform-specific limits, such as those for the minimum and
-maximum <code class="idl"><a data-link-type="idl" href="https://w3c.github.io/FileAPI/#dfn-Blob">Blob</a></code> size that it will support, or the number of <code class="idl"><a data-link-type="idl" href="https://www.w3.org/TR/mediacapture-streams/#mediastreamtrack">MediaStreamTrack</a></code>s it will record at once.
-It will signal a fatal error if these limits are exceeded.</p>
+   <p>If at any moment the UA finds an error condition, the UA MUST run the following
+steps:</p>
+   <ol>
+    <li>
+     If <code class="idl"><a data-link-type="idl" href="#dom-mediarecorder-state" id="ref-for-dom-mediarecorder-state-15">state</a></code> is <code class="idl"><a data-link-type="idl" href="#dom-recordingstate-inactive" id="ref-for-dom-recordingstate-inactive-12">inactive</a></code> throw an <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#invalidstateerror">InvalidStateError</a></code> <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code> and terminate these steps. Otherwise the UA MUST queue a
+    task, using the DOM manipulation task source, that runs the following steps: 
+     <ol>
+      <li>Set <code class="idl"><a data-link-type="idl" href="#dom-mediarecorder-state" id="ref-for-dom-mediarecorder-state-16">state</a></code> to <code class="idl"><a data-link-type="idl" href="#dom-recordingstate-inactive" id="ref-for-dom-recordingstate-inactive-13">inactive</a></code> and stop gathering data.
+      <li>Let <var>blob</var> be the <code class="idl"><a data-link-type="idl" href="https://w3c.github.io/FileAPI/#dfn-Blob">Blob</a></code> of collected data so far and
+      let <var>target</var> be the MediaRecorder context object
+      <li><a href="#to-fire-a-blob-event" id="ref-for-to-fire-a-blob-event-7">Fire a blob event</a> named <a data-link-type="dfn" href="#dataavailable" id="ref-for-dataavailable-8">dataavailable</a> at <var>target</var> with <var>blob</var>.
+      <li><a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-event-fire">Fire an event</a> named <a data-link-type="dfn" href="#stop" id="ref-for-stop-6">stop</a> at <var>target</var>
+      <li><a data-link-type="dfn" href="#fire-an-error-event" id="ref-for-fire-an-error-event-3">Fire an error event</a> named <code class="idl"><a data-link-type="idl" href="#mediarecordererrorevent" id="ref-for-mediarecordererrorevent-2">MediaRecorderErrorEvent</a></code> at <var>target</var>.
+     </ol>
+   </ol>
+   <div class="note" role="note"> The UA may set platform-specific limits, such as those for the minimum and
+  maximum <code class="idl"><a data-link-type="idl" href="https://w3c.github.io/FileAPI/#dfn-Blob">Blob</a></code> size that it will support, or the number of <code class="idl"><a data-link-type="idl" href="https://www.w3.org/TR/mediacapture-streams/#mediastreamtrack">MediaStreamTrack</a></code>s it will record at once. It will signal a fatal error if
+  these limits are exceeded. </div>
    <h3 class="heading settled" data-level="4.2" id="errorevent-section"><span class="secno">4.2. </span><span class="content">MediaRecorderErrorEvent</span><a class="self-link" href="#errorevent-section"></a></h3>
    <p>The <code class="idl"><a data-link-type="idl" href="#mediarecordererrorevent" id="ref-for-mediarecordererrorevent-3">MediaRecorderErrorEvent</a></code> interface is defined for cases when an event is
 raised that was caused by an error.</p>
@@ -2437,6 +2446,7 @@ specific type.</p>
     <li><a href="#ref-for-dom-mediarecorder-state-1">2. Media Recorder API</a>
     <li><a href="#ref-for-dom-mediarecorder-state-2">2.3. Methods</a> <a href="#ref-for-dom-mediarecorder-state-3">(2)</a> <a href="#ref-for-dom-mediarecorder-state-4">(3)</a> <a href="#ref-for-dom-mediarecorder-state-5">(4)</a> <a href="#ref-for-dom-mediarecorder-state-6">(5)</a> <a href="#ref-for-dom-mediarecorder-state-7">(6)</a> <a href="#ref-for-dom-mediarecorder-state-8">(7)</a> <a href="#ref-for-dom-mediarecorder-state-9">(8)</a> <a href="#ref-for-dom-mediarecorder-state-10">(9)</a> <a href="#ref-for-dom-mediarecorder-state-11">(10)</a> <a href="#ref-for-dom-mediarecorder-state-12">(11)</a> <a href="#ref-for-dom-mediarecorder-state-13">(12)</a>
     <li><a href="#ref-for-dom-mediarecorder-state-14">2.4. Data handling</a>
+    <li><a href="#ref-for-dom-mediarecorder-state-15">4.1. General principles</a> <a href="#ref-for-dom-mediarecorder-state-16">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dom-mediarecorder-onstart">
@@ -2588,6 +2598,7 @@ specific type.</p>
     <li><a href="#ref-for-dom-recordingstate-inactive-1">2.2. Attributes</a>
     <li><a href="#ref-for-dom-recordingstate-inactive-2">2.3. Methods</a> <a href="#ref-for-dom-recordingstate-inactive-3">(2)</a> <a href="#ref-for-dom-recordingstate-inactive-4">(3)</a> <a href="#ref-for-dom-recordingstate-inactive-5">(4)</a> <a href="#ref-for-dom-recordingstate-inactive-6">(5)</a> <a href="#ref-for-dom-recordingstate-inactive-7">(6)</a> <a href="#ref-for-dom-recordingstate-inactive-8">(7)</a> <a href="#ref-for-dom-recordingstate-inactive-9">(8)</a> <a href="#ref-for-dom-recordingstate-inactive-10">(9)</a>
     <li><a href="#ref-for-dom-recordingstate-inactive-11">2.6. RecordingState</a>
+    <li><a href="#ref-for-dom-recordingstate-inactive-12">4.1. General principles</a> <a href="#ref-for-dom-recordingstate-inactive-13">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dom-recordingstate-recording">
@@ -2709,6 +2720,7 @@ specific type.</p>
    <ul>
     <li><a href="#ref-for-stop-1">2.2. Attributes</a>
     <li><a href="#ref-for-stop-2">2.3. Methods</a> <a href="#ref-for-stop-3">(2)</a> <a href="#ref-for-stop-4">(3)</a> <a href="#ref-for-stop-5">(4)</a>
+    <li><a href="#ref-for-stop-6">4.1. General principles</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dataavailable">
@@ -2716,6 +2728,7 @@ specific type.</p>
    <ul>
     <li><a href="#ref-for-dataavailable-1">2.2. Attributes</a>
     <li><a href="#ref-for-dataavailable-2">2.3. Methods</a> <a href="#ref-for-dataavailable-3">(2)</a> <a href="#ref-for-dataavailable-4">(3)</a> <a href="#ref-for-dataavailable-5">(4)</a> <a href="#ref-for-dataavailable-6">(5)</a> <a href="#ref-for-dataavailable-7">(6)</a>
+    <li><a href="#ref-for-dataavailable-8">4.1. General principles</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="pause">

--- a/MediaRecorder.html
+++ b/MediaRecorder.html
@@ -1966,7 +1966,7 @@ its <code class="idl"><a data-link-type="idl" href="#dom-blobevent-data" id="ref
 that the call is made. In all other cases the UA will <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-event-fire">fire an event</a> named <code class="idl"><a data-link-type="idl" href="#mediarecordererrorevent" id="ref-for-mediarecordererrorevent-2">MediaRecorderErrorEvent</a></code>.  If recording has been started and not yet stopped
 when the error occurs, let <var>blob</var> be the <code class="idl"><a data-link-type="idl" href="https://w3c.github.io/FileAPI/#dfn-Blob">Blob</a></code> of collected data so
 far; before raising the error, the UA will <a href="#to-fire-a-blob-event" id="ref-for-to-fire-a-blob-event-7">fire a
-dataavailable event</a> with <var>blob</var>; then the UA will <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-event-fire">fire an event</a> named <code>stop</code>; finally the UA will <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-event-fire">fire an event</a> named <code>error</code>.
+dataavailable event</a> with <var>blob</var>; then the UA will <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-event-fire">fire an event</a> named <code>stop</code>; finally the UA will <a data-link-type="dfn" href="#fire-an-error-event" id="ref-for-fire-an-error-event-3">fire an error event</a>.
 The UA may set platform-specific limits, such as those for the minimum and
 maximum <code class="idl"><a data-link-type="idl" href="https://w3c.github.io/FileAPI/#dfn-Blob">Blob</a></code> size that it will support, or the number of <code class="idl"><a data-link-type="idl" href="https://www.w3.org/TR/mediacapture-streams/#mediastreamtrack">MediaStreamTrack</a></code>s it will record at once.
 It will signal a fatal error if these limits are exceeded.</p>
@@ -2659,6 +2659,7 @@ specific type.</p>
    <b><a href="#fire-an-error-event">#fire-an-error-event</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-fire-an-error-event-1">2.3. Methods</a> <a href="#ref-for-fire-an-error-event-2">(2)</a>
+    <li><a href="#ref-for-fire-an-error-event-3">4.1. General principles</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dictdef-mediarecordererroreventinit">

--- a/MediaRecorder.html
+++ b/MediaRecorder.html
@@ -1758,7 +1758,7 @@ at regular intervals.</p>
         <td class="prmNullFalse"><span aria-label="False" role="img">✘</span>
         <td class="prmOptTrue"><span aria-label="True" role="img">✔</span>
         <td class="prmDesc">The minimum number of milliseconds of data
-        to return in a single Blob.
+        to return in a single <code class="idl"><a data-link-type="idl" href="https://w3c.github.io/FileAPI/#dfn-Blob">Blob</a></code>.
      </table>
     <dt><dfn class="dfn-paneled idl-code" data-dfn-for="MediaRecorder" data-dfn-type="method" data-export="" id="dom-mediarecorder-stop"><code>stop()</code></dfn>
     <dd>
@@ -1770,7 +1770,7 @@ at regular intervals.</p>
     task, using the DOM manipulation task source, that runs the following steps: 
        <ol>
         <li>Set <code class="idl"><a data-link-type="idl" href="#dom-mediarecorder-state" id="ref-for-dom-mediarecorder-state-8">state</a></code> to <code class="idl"><a data-link-type="idl" href="#dom-recordingstate-inactive" id="ref-for-dom-recordingstate-inactive-7">inactive</a></code> and stop gathering data.
-        <li>Let <var>blob</var> be the Blob of collected data so far and
+        <li>Let <var>blob</var> be the <code class="idl"><a data-link-type="idl" href="https://w3c.github.io/FileAPI/#dfn-Blob">Blob</a></code> of collected data so far and
       let <var>target</var> be the MediaRecorder context object, then <a href="#to-fire-a-blob-event" id="ref-for-to-fire-a-blob-event-5">fire a blob event</a> named <a data-link-type="dfn" href="#dataavailable" id="ref-for-dataavailable-6">dataavailable</a> at <var>target</var> with <var>blob</var>.
         <li><a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-event-fire">Fire an event</a> named <a data-link-type="dfn" href="#stop" id="ref-for-stop-5">stop</a> at <var>target</var>.
        </ol>
@@ -1821,7 +1821,7 @@ at regular intervals.</p>
       let <var>target</var> be the <code class="idl"><a data-link-type="idl" href="#mediarecorder" id="ref-for-mediarecorder-11">MediaRecorder</a></code> context object, then <a href="#to-fire-a-blob-event" id="ref-for-to-fire-a-blob-event-6">fire a blob event</a> named <a data-link-type="dfn" href="#dataavailable" id="ref-for-dataavailable-7">dataavailable</a> at <var>target</var> with <var>blob</var>.
       (Note that <var>blob</var> will be empty if no data has been gathered
       yet.)
-        <li>Create a new Blob and gather subsequent data into it.
+        <li>Create a new <code class="idl"><a data-link-type="idl" href="https://w3c.github.io/FileAPI/#dfn-Blob">Blob</a></code> and gather subsequent data into it.
        </ol>
       <li>return <code>undefined</code>.
      </ol>
@@ -1961,31 +1961,26 @@ its <code class="idl"><a data-link-type="idl" href="#dom-blobevent-data" id="ref
    </dl>
    <h2 class="heading settled" data-level="4" id="error-handling"><span class="secno">4. </span><span class="content">Error handling</span><a class="self-link" href="#error-handling"></a></h2>
    <h3 class="heading settled" data-level="4.1" id="error-handling-principles"><span class="secno">4.1. </span><span class="content">General principles</span><a class="self-link" href="#error-handling-principles"></a></h3>
-   <p>If at any moment the UA finds an error condition, the UA MUST run the following
-steps:</p>
+   <p>If at any moment the UA finds an error condition, the UA MUST queue a task,
+using the DOM manipulation task source, that runs the following steps:</p>
    <ol>
-    <li>
-     If <code class="idl"><a data-link-type="idl" href="#dom-mediarecorder-state" id="ref-for-dom-mediarecorder-state-15">state</a></code> is <code class="idl"><a data-link-type="idl" href="#dom-recordingstate-inactive" id="ref-for-dom-recordingstate-inactive-12">inactive</a></code> throw an <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#invalidstateerror">InvalidStateError</a></code> <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code> and terminate these steps. Otherwise the UA MUST queue a
-    task, using the DOM manipulation task source, that runs the following steps: 
-     <ol>
-      <li>Set <code class="idl"><a data-link-type="idl" href="#dom-mediarecorder-state" id="ref-for-dom-mediarecorder-state-16">state</a></code> to <code class="idl"><a data-link-type="idl" href="#dom-recordingstate-inactive" id="ref-for-dom-recordingstate-inactive-13">inactive</a></code> and stop gathering data.
-      <li>Let <var>blob</var> be the <code class="idl"><a data-link-type="idl" href="https://w3c.github.io/FileAPI/#dfn-Blob">Blob</a></code> of collected data so far and
-      let <var>target</var> be the MediaRecorder context object
-      <li><a href="#to-fire-a-blob-event" id="ref-for-to-fire-a-blob-event-7">Fire a blob event</a> named <a data-link-type="dfn" href="#dataavailable" id="ref-for-dataavailable-8">dataavailable</a> at <var>target</var> with <var>blob</var>.
-      <li><a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-event-fire">Fire an event</a> named <a data-link-type="dfn" href="#stop" id="ref-for-stop-6">stop</a> at <var>target</var>
-      <li><a data-link-type="dfn" href="#fire-an-error-event" id="ref-for-fire-an-error-event-3">Fire an error event</a> named <code class="idl"><a data-link-type="idl" href="#mediarecordererrorevent" id="ref-for-mediarecordererrorevent-2">MediaRecorderErrorEvent</a></code> at <var>target</var>.
-     </ol>
+    <li>Set <code class="idl"><a data-link-type="idl" href="#dom-mediarecorder-state" id="ref-for-dom-mediarecorder-state-15">state</a></code> to <code class="idl"><a data-link-type="idl" href="#dom-recordingstate-inactive" id="ref-for-dom-recordingstate-inactive-12">inactive</a></code> and stop gathering data.
+    <li>Let <var>blob</var> be the <code class="idl"><a data-link-type="idl" href="https://w3c.github.io/FileAPI/#dfn-Blob">Blob</a></code> of collected data so far and
+  let <var>target</var> be the MediaRecorder context object
+    <li><a href="#to-fire-a-blob-event" id="ref-for-to-fire-a-blob-event-7">Fire a blob event</a> named <a data-link-type="dfn" href="#dataavailable" id="ref-for-dataavailable-8">dataavailable</a> at <var>target</var> with <var>blob</var>.
+    <li><a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-event-fire">Fire an event</a> named <a data-link-type="dfn" href="#stop" id="ref-for-stop-6">stop</a> at <var>target</var>
+    <li><a data-link-type="dfn" href="#fire-an-error-event" id="ref-for-fire-an-error-event-3">Fire an error event</a> named <var>event</var> at <var>target</var>.
    </ol>
-   <div class="note" role="note"> The UA may set platform-specific limits, such as those for the minimum and
-  maximum <code class="idl"><a data-link-type="idl" href="https://w3c.github.io/FileAPI/#dfn-Blob">Blob</a></code> size that it will support, or the number of <code class="idl"><a data-link-type="idl" href="https://www.w3.org/TR/mediacapture-streams/#mediastreamtrack">MediaStreamTrack</a></code>s it will record at once. It will signal a fatal error if
-  these limits are exceeded. </div>
+   <div class="note" role="note"> The UA MAY set platform-specific limits, e.g. for the minimum and maximum <code class="idl"><a data-link-type="idl" href="https://w3c.github.io/FileAPI/#dfn-Blob">Blob</a></code> size that it will support, or the number of <code class="idl"><a data-link-type="idl" href="https://www.w3.org/TR/mediacapture-streams/#mediastreamtrack">MediaStreamTrack</a></code>s it
+  will record at once. It will signal a fatal error if these limits are
+  exceeded. </div>
    <h3 class="heading settled" data-level="4.2" id="errorevent-section"><span class="secno">4.2. </span><span class="content">MediaRecorderErrorEvent</span><a class="self-link" href="#errorevent-section"></a></h3>
-   <p>The <code class="idl"><a data-link-type="idl" href="#mediarecordererrorevent" id="ref-for-mediarecordererrorevent-3">MediaRecorderErrorEvent</a></code> interface is defined for cases when an event is
+   <p>The <code class="idl"><a data-link-type="idl" href="#mediarecordererrorevent" id="ref-for-mediarecordererrorevent-2">MediaRecorderErrorEvent</a></code> interface is defined for cases when an event is
 raised that was caused by an error.</p>
    <p><dfn class="dfn-paneled" data-dfn-type="dfn" data-lt="fire an error event" data-noexport="" id="fire-an-error-event">To fire an error event</dfn> named <var>e</var> with a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code> named <var>error</var> means that an
 event with the name <var>e</var>, which does not bubble (except where otherwise
 stated) and is not cancelable (except where otherwise stated), and which uses
-the <code class="idl"><a data-link-type="idl" href="#mediarecordererrorevent" id="ref-for-mediarecordererrorevent-4">MediaRecorderErrorEvent</a></code> interface with the <code class="idl"><a data-link-type="idl" href="#dom-mediarecordererrorevent-error" id="ref-for-dom-mediarecordererrorevent-error-1">error</a></code> attribute set to <var>error</var>, must be
+the <code class="idl"><a data-link-type="idl" href="#mediarecordererrorevent" id="ref-for-mediarecordererrorevent-3">MediaRecorderErrorEvent</a></code> interface with the <code class="idl"><a data-link-type="idl" href="#dom-mediarecordererrorevent-error" id="ref-for-dom-mediarecordererrorevent-error-1">error</a></code> attribute set to <var>error</var>, must be
 created and <a href="https://dom.spec.whatwg.org/#concept-event-dispatch">dispatched</a> at
 the given target.</p>
    <p></p>
@@ -2002,7 +1997,7 @@ the given target.</p>
    <dl class="domintro">
     <dt><dfn class="dfn-paneled idl-code" data-dfn-for="MediaRecorderErrorEvent" data-dfn-type="constructor" data-export="" data-lt="MediaRecorderErrorEvent(type, eventInitDict)" id="dom-mediarecordererrorevent-mediarecordererrorevent"><code>MediaRecorderErrorEvent(DOMString type, MediaRecorderErrorEventInit eventInitDict)</code></dfn>
     <dd>
-      Constructs a new <code class="idl"><a data-link-type="idl" href="#mediarecordererrorevent" id="ref-for-mediarecordererrorevent-5">MediaRecorderErrorEvent</a></code>. 
+      Constructs a new <code class="idl"><a data-link-type="idl" href="#mediarecordererrorevent" id="ref-for-mediarecordererrorevent-4">MediaRecorderErrorEvent</a></code>. 
      <table class="parameters">
       <tbody>
        <tr>
@@ -2098,7 +2093,7 @@ specific type.</p>
       <td>The UA has resumed recording data from the MediaStream.
      <tr>
       <td><dfn data-dfn-type="dfn" data-noexport="" id="error">error<a class="self-link" href="#error"></a></dfn>
-      <td><code class="idl"><a data-link-type="idl" href="#mediarecordererrorevent" id="ref-for-mediarecordererrorevent-6">MediaRecorderErrorEvent</a></code>
+      <td><code class="idl"><a data-link-type="idl" href="#mediarecordererrorevent" id="ref-for-mediarecordererrorevent-5">MediaRecorderErrorEvent</a></code>
       <td>An error has occurred, e.g. out of memory or a modification to
       the <code class="idl"><a data-link-type="idl" href="#dom-mediarecorder-stream" id="ref-for-dom-mediarecorder-stream-7">stream</a></code> has occurred that makes it impossible to
       continue recording (e.g. a Track has been added to or removed from
@@ -2455,7 +2450,7 @@ the <code class="idl"><a data-link-type="idl" href="https://www.w3.org/TR/mediac
     <li><a href="#ref-for-dom-mediarecorder-state-1">2. Media Recorder API</a>
     <li><a href="#ref-for-dom-mediarecorder-state-2">2.3. Methods</a> <a href="#ref-for-dom-mediarecorder-state-3">(2)</a> <a href="#ref-for-dom-mediarecorder-state-4">(3)</a> <a href="#ref-for-dom-mediarecorder-state-5">(4)</a> <a href="#ref-for-dom-mediarecorder-state-6">(5)</a> <a href="#ref-for-dom-mediarecorder-state-7">(6)</a> <a href="#ref-for-dom-mediarecorder-state-8">(7)</a> <a href="#ref-for-dom-mediarecorder-state-9">(8)</a> <a href="#ref-for-dom-mediarecorder-state-10">(9)</a> <a href="#ref-for-dom-mediarecorder-state-11">(10)</a> <a href="#ref-for-dom-mediarecorder-state-12">(11)</a> <a href="#ref-for-dom-mediarecorder-state-13">(12)</a>
     <li><a href="#ref-for-dom-mediarecorder-state-14">2.4. Data handling</a>
-    <li><a href="#ref-for-dom-mediarecorder-state-15">4.1. General principles</a> <a href="#ref-for-dom-mediarecorder-state-16">(2)</a>
+    <li><a href="#ref-for-dom-mediarecorder-state-15">4.1. General principles</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dom-mediarecorder-onstart">
@@ -2609,7 +2604,7 @@ the <code class="idl"><a data-link-type="idl" href="https://www.w3.org/TR/mediac
     <li><a href="#ref-for-dom-recordingstate-inactive-1">2.2. Attributes</a>
     <li><a href="#ref-for-dom-recordingstate-inactive-2">2.3. Methods</a> <a href="#ref-for-dom-recordingstate-inactive-3">(2)</a> <a href="#ref-for-dom-recordingstate-inactive-4">(3)</a> <a href="#ref-for-dom-recordingstate-inactive-5">(4)</a> <a href="#ref-for-dom-recordingstate-inactive-6">(5)</a> <a href="#ref-for-dom-recordingstate-inactive-7">(6)</a> <a href="#ref-for-dom-recordingstate-inactive-8">(7)</a> <a href="#ref-for-dom-recordingstate-inactive-9">(8)</a> <a href="#ref-for-dom-recordingstate-inactive-10">(9)</a>
     <li><a href="#ref-for-dom-recordingstate-inactive-11">2.6. RecordingState</a>
-    <li><a href="#ref-for-dom-recordingstate-inactive-12">4.1. General principles</a> <a href="#ref-for-dom-recordingstate-inactive-13">(2)</a>
+    <li><a href="#ref-for-dom-recordingstate-inactive-12">4.1. General principles</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dom-recordingstate-recording">
@@ -2695,10 +2690,9 @@ the <code class="idl"><a data-link-type="idl" href="https://www.w3.org/TR/mediac
    <b><a href="#mediarecordererrorevent">#mediarecordererrorevent</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-mediarecordererrorevent-1">2.2. Attributes</a>
-    <li><a href="#ref-for-mediarecordererrorevent-2">4.1. General principles</a>
-    <li><a href="#ref-for-mediarecordererrorevent-3">4.2. MediaRecorderErrorEvent</a> <a href="#ref-for-mediarecordererrorevent-4">(2)</a>
-    <li><a href="#ref-for-mediarecordererrorevent-5">4.2.1. Constructors</a>
-    <li><a href="#ref-for-mediarecordererrorevent-6">5. Event summary</a>
+    <li><a href="#ref-for-mediarecordererrorevent-2">4.2. MediaRecorderErrorEvent</a> <a href="#ref-for-mediarecordererrorevent-3">(2)</a>
+    <li><a href="#ref-for-mediarecordererrorevent-4">4.2.1. Constructors</a>
+    <li><a href="#ref-for-mediarecordererrorevent-5">5. Event summary</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dom-mediarecordererrorevent-mediarecordererrorevent">


### PR DESCRIPTION
Upon an error condition, first fire an Event called `ondataavailable`, then an Event called `stop` and finally fire an error event.

Addresses #52 .

Chrome update in progress in https://crrev.com/2697703003


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/yellowdoge/mediacapture-record/pull/118.html" title="Last updated on Feb 15, 2021, 7:32 AM UTC (96db655)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/mediacapture-record/118/faf208b...yellowdoge:96db655.html" title="Last updated on Feb 15, 2021, 7:32 AM UTC (96db655)">Diff</a>