### PR TITLE
Remove 'Level:1' from the bikeshed metadata

### DIFF
--- a/MediaRecorder.bs
+++ b/MediaRecorder.bs
@@ -6,7 +6,6 @@ Status: ED
 ED: https://w3c.github.io/mediacapture-record/
 TR: https://www.w3.org/TR/mediastream-recording/
 Shortname: mediastream-recording
-Level: 1
 Editor: Miguel Casas-Sanchez, w3cid 82825, Google Inc., mcasas@google.com
 Former Editor: Jim Barnett, w3cid 34604, Genesis
 Former Editor: Travis Leithead, w3cid 40117, Microsoft Corp., travis.leithead@microsoft.com


### PR DESCRIPTION
Because it rubs echidna the wrong way, see e.g. https://labs.w3.org/echidna/api/status?id=8e53bf59-3514-46fb-a8e4-41f04bf74d79:

```
      "specberus": {
        "status": "failure",
        "errors": [{
          "key": "this-latest-shortname",
          "type": {
            "name": "headers.dl",
            "section": "front-matter",
            "rule": "docIDFormat"
          }
        }
```