### PR TITLE
Correct removing Level: 1, instead expliciting Level: none

### DIFF
--- a/MediaRecorder.bs
+++ b/MediaRecorder.bs
@@ -6,6 +6,7 @@ Status: ED
 ED: https://w3c.github.io/mediacapture-record/
 TR: https://www.w3.org/TR/mediastream-recording/
 Shortname: mediastream-recording
+Level: none
 Editor: Miguel Casas-Sanchez, w3cid 82825, Google Inc., mcasas@google.com
 Former Editor: Jim Barnett, w3cid 34604, Genesis
 Former Editor: Travis Leithead, w3cid 40117, Microsoft Corp., travis.leithead@microsoft.com


### PR DESCRIPTION
following https://github.com/w3c/mediacapture-image/pull/190