### PR TITLE
Make pause(),resume() and stop() idempotent.

### DIFF
--- a/MediaRecorder.bs
+++ b/MediaRecorder.bs
@@ -315,8 +315,7 @@ interface MediaRecorder : EventTarget {
   When a {{MediaRecorder}} object&#8217;s {{stop()}} method is invoked, the UA
   MUST run the following steps:
   <ol>
-    <li>If {{state}} is {{inactive}}, throw an {{InvalidStateError}}
-    {{DOMException}} and abort these steps.</li>
+    <li>If {{state}} is {{inactive}}, abort these steps.</li>
 
     <li>Set {{state}} to {{inactive}}, and queue a
     task, using the DOM manipulation task source, that runs the following steps:

--- a/MediaRecorder.bs
+++ b/MediaRecorder.bs
@@ -341,6 +341,8 @@ interface MediaRecorder : EventTarget {
     <li>If {{state}} is {{inactive}}, throw an {{InvalidStateError}}
     {{DOMException}} and abort these steps.</li>
 
+    <li>If {{state}} is {{paused}}, abort these steps.</li>
+
     <li>Set {{state}} to {{paused}}, and queue a
     task, using the DOM manipulation task source, that runs the following steps:
     <ol>
@@ -361,6 +363,8 @@ interface MediaRecorder : EventTarget {
   <ol>
     <li>If {{state}} is {{inactive}}, throw an {{InvalidStateError}}
     {{DOMException}} and abort these steps.</li>
+
+    <li>If {{state}} is {{recording}}, abort these steps.</li>
 
     <li>Set {{state}} to {{recording}}, and queue a
     task, using the DOM manipulation task source, that runs the following steps:


### PR DESCRIPTION
Fix for https://github.com/w3c/mediacapture-record/issues/150.

~~Note: this PR is on top of https://github.com/w3c/mediacapture-record/pull/157 because git. Please look at the third commit and on.~~