### PR TITLE
Clarify MediaRecorder's mimeType handling

### DIFF
--- a/MediaRecorder.bs
+++ b/MediaRecorder.bs
@@ -111,8 +111,7 @@ interface MediaRecorder : EventTarget {
         "False">&#10008;</span></td>
         <td class="prmOptTrue"><span role="img" aria-label=
         "True">&#10004;</span></td>
-        <td class="prmDesc">A dictionary of options to for the UA instructing
-        how the recording will take part.</td>
+        <td class="prmDesc">A dictionary of recording options.</td>
       </tr>
     </tbody>
   </table>
@@ -120,20 +119,15 @@ interface MediaRecorder : EventTarget {
   <dd algorithm="to construct a MediaRecorder">When the {{MediaRecorder()}}
   constructor is invoked, the User Agent MUST run the following steps:
   <ol>
-    <li>Let |recorder| be the newly constructed {{MediaRecorder}}.</li>
+    <li>Let |recorder| be a newly constructed {{MediaRecorder}} object.</li>
     <li>Initialize |recorder|'s {{MediaRecorder/stream}} attribute to the
     constructor's first argument.</li>
     <li>Each {{MediaRecorder}} has an internal <dfn>constrainedMimeType</dfn>
     property that is initially set to the empty string.</li>
-    <li>If the constructor's second argument |options| is present, run the
-    following steps:
-    <ol>
-      <li>If |options|' {{MediaRecorderOptions/mimeType}} member is present, set
-      the [=constrainedMimeType=] internal property to the value of |options|'
-      {{MediaRecorderOptions/mimeType}} member.</li>
-    </ol>
-    </li>
-    <li>If invoking {{isTypeSupported()}} with the [=constrainedMimeType=]
+    <li>If the {{MediaRecorderOptions/mimeType}} member is present in the
+    constructor's second argument, set the [=constrainedMimeType=] internal
+    property to the value of {{MediaRecorderOptions/mimeType}}.</li>
+    <li>If invoking [$is type supported$] with the [=constrainedMimeType=]
     internal property as its argument returns false, throw a
     {{NotSupportedError}} {{DOMException}} and abort these steps.</li>
     <li>Initialize |recorder|'s {{MediaRecorder/mimeType}} attribute to the
@@ -227,24 +221,33 @@ interface MediaRecorder : EventTarget {
     [=track set=].</li>
 
     <li>If the [=constrainedMimeType=] internal property specifies a media type,
-    container, or codec such that the User Agent cannot record a track in
-    |tracks| with it, throw a {{NotSupportedError}} {{DOMException}} and abort
-    these steps.</li>
+    container, or codec, then run the following sub steps:
+    <ol>
+      <li>Constrain the configuration of the MediaRecorder to the media type,
+      container, and codec specified in [=constrainedMimeType=].</li>
+      <li>For each track in |tracks|, if the User Agent cannot record the track
+      using the current configuration, then throw a {{NotSupportedError}}
+      {{DOMException}} and abort all steps.</li>
+    </ol>
+    </li>
 
-    <li>Set {{mimeType}} to the [=constrainedMimeType=] internal property,
-    extended by the media type, subtype and codecs parameter reflecting the
-    configuration used by the MediaRecorder to record all tracks in |tracks|.
-    The media type, subtype and any parameters in the [=constrainedMimeType=]
-    internal property, MUST NOT be changed. {{mimeType}} MAY be extended with
-    the profiles parameter [[RFC6381]] or further codec-specific parameters to
-    avoid ambiguity.</li>
+    <li>Let |extendedMimeType| be the value of the [=constrainedMimeType=]
+    internal property.</li>
+
+    <li>Modify |extendedMimeType| by adding media type, subtype and codecs
+    parameter reflecting the configuration used by the MediaRecorder to record
+    all tracks in |tracks|, if not already present. This MAY include the
+    profiles parameter [[RFC6381]] or further codec-specific parameters.</li>
+
+    <li>Set {{mimeType}} to |extendedMimeType|.</li>
 
     <li>Set {{state}} to {{recording}}, and run the following steps in parallel:
     <ol>
-      <li>Start recording all tracks in |tracks| and gather the data into a
-      {{Blob}} <var>blob</var> and queue a task, using the DOM manipulation task
-      source, to <a>fire an event</a> named <a>start</a> at <var>target</var>,
-      then return <code>undefined</code>.</li>
+      <li>Start recording all tracks in |tracks| using the {{MediaRecorder}}'s
+      current configuration, and gather the data into a {{Blob}} <var>blob</var>
+      and queue a task, using the DOM manipulation task source, to
+      <a>fire an event</a> named <a>start</a> at <var>target</var>, then return
+      <code>undefined</code>.</li>
 
       <li>If at any point the {{stream}}'s <a>isolation properties</a> change so
       that {{MediaRecorder}} is no longer allowed access to it, the UA MUST
@@ -458,26 +461,8 @@ interface MediaRecorder : EventTarget {
   {{MediaRecorder}} implementation is capable of recording {{Blob}} objects for
   the specified MIME type. Recording may still fail if sufficient resources are
   not available to support the concrete media encoding. When this method is
-  invoked, the User Agent must run the following steps:
-  <ol class="method-algorithm">
-    <li>If <code>type</code> is an empty string, then return true
-    (note that this case is essentially equivalent to leaving up to
-    the UA the choice of both container and codecs).</li>
-    <li>If <code>type</code> does not contain a valid MIME type
-    string, then return false.</li>
-    <li>If <code>type</code> contains a media type or media subtype
-    that the MediaRecorder does not support, then return false.</li>
-    <li>If <code>type</code> contains a media container that the
-    MediaRecorder does not support, then return false.</li>
-    <li>If <code>type</code> contains more than one audio codec, or more than
-    one video codec, then return false.</li>
-    <li>If <code>type</code> contains a codec that the MediaRecorder
-    does not support, then return false.</li>
-    <li>If the MediaRecorder does not support the specified
-    combination of media type/subtype, codecs and container then
-    return false.</li>
-    <li>Return true.</li>
-  </ol>
+  invoked, the User Agent must return the result of [$is type supported$],
+  given the method's first argument.
   <table class="parameters">
     <tbody>
       <tr>
@@ -500,6 +485,28 @@ interface MediaRecorder : EventTarget {
       </tr>
     </tbody>
   </table>
+  </dd>
+  <dd algorithm="is type supported">The <dfn abstract-op>is type supported</dfn>
+  algorithm consists of the following steps.
+  <ol>
+    <li>Let |type| be the algorithm's argument.</li>
+    <li>If |type| is an empty string, then return true (note that this case is
+    essentially equivalent to leaving up to the UA the choice of both container
+    and codecs).</li>
+    <li>If |type| does not contain a valid MIME type string, then return false.
+    </li>
+    <li>If |type| contains a media type or media subtype that the MediaRecorder
+    does not support, then return false.</li>
+    <li>If |type| contains a media container that the MediaRecorder does not
+    support, then return false.</li>
+    <li>If |type| contains more than one audio codec, or more than one video
+    codec, then return false.</li>
+    <li>If |type| contains a codec that the MediaRecorder does not support, then
+    return false.</li>
+    <li>If the MediaRecorder does not support the specified combination of media
+    type/subtype, codecs and container then return false.</li>
+    <li>Return true.</li>
+  </ol>
   </dd>
 </dl>
 

--- a/MediaRecorder.bs
+++ b/MediaRecorder.bs
@@ -112,13 +112,36 @@ interface MediaRecorder : EventTarget {
         <td class="prmOptTrue"><span role="img" aria-label=
         "True">&#10004;</span></td>
         <td class="prmDesc">A dictionary of options to for the UA instructing
-        how the recording will take part.
-        {{MediaRecorderOptions/mimeType|options.mimeType}}, if present, will
-        become the value of {{MediaRecorder/mimeType}} attribute.</td>
+        how the recording will take part.</td>
       </tr>
     </tbody>
   </table>
   </dd>
+  <dd algorithm="to construct a MediaRecorder">When the {{MediaRecorder()}}
+  constructor is invoked, the User Agent MUST run the following steps:
+  <ol>
+    <li>Let |recorder| be the newly constructed {{MediaRecorder}}.</li>
+    <li>Initialize |recorder|'s {{MediaRecorder/stream}} attribute to the
+    constructor's first argument.</li>
+    <li>Each {{MediaRecorder}} has an internal <dfn>constrainedMimeType</dfn>
+    property that is initially set to the empty string.</li>
+    <li>If the constructor's second argument |options| is present, run the
+    following steps:
+    <ol>
+      <li>If |options|' {{MediaRecorderOptions/mimeType}} member is present, set
+      the [=constrainedMimeType=] internal property to the value of |options|'
+      {{MediaRecorderOptions/mimeType}} member.</li>
+    </ol>
+    </li>
+    <li>If invoking {{isTypeSupported()}} with the [=constrainedMimeType=]
+    internal property as its argument returns false, throw a
+    {{NotSupportedError}} {{DOMException}} and abort these steps.</li>
+    <li>Initialize |recorder|'s {{MediaRecorder/mimeType}} attribute to the
+    [=constrainedMimeType=] internal property.</li>
+    <li>Initialize |recorder|'s {{MediaRecorder/state}} attribute to
+    {{inactive}}.</li>
+    <li>Return |recorder|.</li>
+  </ol></dd>
 </dl>
 
 ## Attributes ## {#mediarecorder-attributes}
@@ -128,12 +151,10 @@ interface MediaRecorder : EventTarget {
   <dd>The {{MediaStream}} [[!GETUSERMEDIA]] to be recorded.</dd>
 
   <dt><dfn attribute for="MediaRecorder"><code>mimeType</code></dfn></dt>
-  <dd>The MIME type [[!RFC2046]] that has been selected as the container
-  for recording. This entry includes all the parameters to the base
-  <code>mimeType</code>. The UA should be able to play back any of the
-  MIME types it supports for recording. For example, it should be able
-  to display a video recording in the HTML &lt;video&gt; tag. The
-  default value for this property is platform-specific.
+  <dd>The MIME type [[!RFC2046]] used by the {{MediaRecorder}} object.
+  The User Agent SHOULD be able to play back any of the MIME types it supports
+  for recording. For example, it should be able to display a video recording in
+  the HTML &lt;video&gt; tag.
 
   <div class="note"> {{MediaRecorder/mimeType}} specifies the media type and
   container format for the recording via a type/subtype combination, with the
@@ -142,8 +163,7 @@ interface MediaRecorder : EventTarget {
   </div></dd>
 
   <dt><dfn attribute for="MediaRecorder"><code>state</code></dfn></dt>
-  <dd>The current state of the {{MediaRecorder}} object. When the
-  {{MediaRecorder}} is created, the UA MUST set this attribute to {{inactive}}.
+  <dd>The current state of the {{MediaRecorder}} object.
   </dd>
 
   <dt><dfn attribute for="MediaRecorder"><code>onstart</code></dfn></dt>
@@ -185,7 +205,7 @@ interface MediaRecorder : EventTarget {
     and fire events asynchronously.
   </div>
   <dt><dfn method for="MediaRecorder"><code>start(optional unsigned long timeslice)</code></dfn></dt>
-  <dd>
+  <dd algorithm="to start a MediaRecorder">
   When a {{MediaRecorder}} object&#8217;s {{start()}} method is invoked, the UA
   MUST run the following steps:
   <ol>
@@ -196,23 +216,44 @@ interface MediaRecorder : EventTarget {
     <li>If {{state}} is not {{inactive}}, throw an {{InvalidStateError}}
     {{DOMException}} and abort these steps.</li>
 
-    <li>If the {{MediaRecorder/stream}}'s <a>isolation properties</a> disallow access
+    <li>If the {{stream}}'s <a>isolation properties</a> disallow access
     from this {{MediaRecorder}}, throw a {{SecurityError}} {{DOMException}} and
     abort these steps.</li>
 
+    <li>If the {{stream}} is {{inactive}}, throw a {{NotSupportedError}}
+    {{DOMException}} and abort these steps.</li>
+
+    <li>Let |tracks| be the set of {{live}} tracks in the {{stream}}'s
+    [=track set=].</li>
+
+    <li>If the [=constrainedMimeType=] internal property specifies a media type,
+    container, or codec such that the User Agent cannot record a track in
+    |tracks| with it, throw a {{NotSupportedError}} {{DOMException}} and abort
+    these steps.</li>
+
+    <li>Set {{mimeType}} to the [=constrainedMimeType=] internal property,
+    extended by the media type, subtype and codecs parameter reflecting the
+    configuration used by the MediaRecorder to record all tracks in |tracks|.
+    The media type, subtype and any parameters in the [=constrainedMimeType=]
+    internal property, MUST NOT be changed. {{mimeType}} MAY be extended with
+    the profiles parameter [[RFC6381]] or further codec-specific parameters to
+    avoid ambiguity.</li>
+
     <li>Set {{state}} to {{recording}}, and run the following steps in parallel:
     <ol>
-      <li>Start gathering the data into a {{Blob}} <var>blob</var> and queue a
-      task, using the DOM manipulation task source, to <a>fire an event</a>
-      named <a>start</a> at <var>target</var>, then return <code>undefined</code>.
-      </li>
+      <li>Start recording all tracks in |tracks| and gather the data into a
+      {{Blob}} <var>blob</var> and queue a task, using the DOM manipulation task
+      source, to <a>fire an event</a> named <a>start</a> at <var>target</var>,
+      then return <code>undefined</code>.</li>
 
-      <li>If at any point the {{MediaRecorder/stream}}'s <a>isolation properties</a>
-      change so that {{MediaRecorder}} is no longer allowed access to it, the
-      UA MUST immediately stop gathering data, discard any data that it has
-      gathered, and queue a task, using the DOM manipulation task source, that
-      runs the following steps:
+      <li>If at any point the {{stream}}'s <a>isolation properties</a> change so
+      that {{MediaRecorder}} is no longer allowed access to it, the UA MUST
+      immediately stop gathering data, discard any data that it has gathered,
+      and queue a task, using the DOM manipulation task source, that runs the
+      following steps:
       <ol>
+        <li>Set {{mimeType}} to the value of the [=constrainedMimeType=]
+        internal property.</li>
         <li>Set {{state}} to {{inactive}}.</li>
         <li><a>Fire an error event</a> named {{SecurityError}} at
         <var>target</var>.</li>
@@ -222,10 +263,13 @@ interface MediaRecorder : EventTarget {
       </ol>
       </li>
 
-      <li>If at any point, a track is added to or removed from the {{MediaRecorder/stream}}'s
-      track set, the UA MUST immediately stop gathering data, discard any data that it has gathered,
-      and queue a task, using the DOM manipulation task source, that runs the following steps:
+      <li>If at any point, a track is added to or removed from the {{stream}}'s
+      [=track set=], the UA MUST immediately stop gathering data, discard any
+      data that it has gathered, and queue a task, using the DOM manipulation
+      task source, that runs the following steps:
       <ol>
+        <li>Set {{mimeType}} to the value of the [=constrainedMimeType=]
+        internal property.</li>
         <li>Set {{state}} to {{inactive}}.</li>
         <li><a>Fire an error event</a> named {{InvalidModificationError}} at
         <var>target</var>.</li>
@@ -236,10 +280,12 @@ interface MediaRecorder : EventTarget {
       </li>
 
       <li>If the UA at any point is unable to continue gathering data for
-      reasons other than <a>isolation properties</a> or stream track set, it MUST stop gathering data, and
-      queue a task, using the DOM manipulation task source, that runs the
-      following steps:
+      reasons other than <a>isolation properties</a> or stream [=track set=],
+      it MUST stop gathering data, and queue a task, using the DOM manipulation
+      task source, that runs the following steps:
       <ol>
+        <li>Set {{mimeType}} to the value of the [=constrainedMimeType=]
+        internal property.</li>
         <li>Set {{state}} to {{inactive}}.</li>
         <li><a>Fire an error event</a> named {{UnknownError}} at
         <var>target</var>.</li>
@@ -264,6 +310,8 @@ interface MediaRecorder : EventTarget {
       queue a task, using the DOM manipulation task source, that runs the
       following steps:
       <ol>
+        <li>Set {{mimeType}} to the value of the [=constrainedMimeType=]
+        internal property.</li>
         <li>Set {{state}} to {{inactive}}.</li>
         <li><a href="#to-fire-a-blob-event">Fire a blob event</a> named
         <a>dataavailable</a> at <var>target</var> with <var>blob</var>.</li>
@@ -316,7 +364,8 @@ interface MediaRecorder : EventTarget {
   MUST run the following steps:
   <ol>
     <li>If {{state}} is {{inactive}}, abort these steps.</li>
-
+    <li>Set {{mimeType}} to the value of the [=constrainedMimeType=]
+    internal property.</li>
     <li>Set {{state}} to {{inactive}}, and queue a
     task, using the DOM manipulation task source, that runs the following steps:
     <ol>
@@ -413,13 +462,15 @@ interface MediaRecorder : EventTarget {
   <ol class="method-algorithm">
     <li>If <code>type</code> is an empty string, then return true
     (note that this case is essentially equivalent to leaving up to
-    the UA the choice of container and codecs on constructor).</li>
+    the UA the choice of both container and codecs).</li>
     <li>If <code>type</code> does not contain a valid MIME type
     string, then return false.</li>
     <li>If <code>type</code> contains a media type or media subtype
     that the MediaRecorder does not support, then return false.</li>
     <li>If <code>type</code> contains a media container that the
     MediaRecorder does not support, then return false.</li>
+    <li>If <code>type</code> contains more than one audio codec, or more than
+    one video codec, then return false.</li>
     <li>If <code>type</code> contains a codec that the MediaRecorder
     does not support, then return false.</li>
     <li>If the MediaRecorder does not support the specified
@@ -480,12 +531,7 @@ dictionary MediaRecorderOptions {
 <dl class="domintro">
   <dt><dfn dict-member for="MediaRecorderOptions"><code>mimeType</code></dfn></dt>
   <dd>The container and codec format(s) [[!RFC2046]] for the recording, which
-  may include any parameters that are defined for the format. If the UA does not
-  support the format or any of the parameters specified, it MUST throw a
-  {{NotSupportedError}} {{DOMException}}. If this paramater is not specified,
-  the UA will use a platform-specific default format. The container format,
-  whether passed in to the constructor or defaulted, will be used as the value
-  of the {{MediaRecorder/mimeType}} attribute.
+  may include any parameters that are defined for the format.
 
   <div class="note"> {{MediaRecorderOptions/mimeType}} specifies the media
   type and container format for the recording via a type/subtype
@@ -716,11 +762,10 @@ specific type.
     </tr>
     <tr>
       <td>{{NotSupportedError}}</td>
-      <td>
-        A {{MediaRecorder}} could not be created due to unsupported options
-        (e.g. MIME type) specification. User agents should provide as much
-        additional information as possible in the <code>message</code> attribute.
-      </td>
+      <td>An operation could not be performed because the MIME type was not
+      supported or the set of tracks could not be recorded by the MIME type.
+      User agents should provide as much additional information as possible in
+      the <code>message</code> attribute.</td>
     </tr>
     <tr>
       <td>{{SecurityError}}</td>
@@ -925,15 +970,19 @@ type: interface; text: DOMHighResTimeStamp; url: https://www.w3.org/TR/hr-time/#
 <pre class="anchors">
 urlPrefix: https://www.w3.org/TR/mediacapture-streams/#; type: interface; text: MediaStream; url: mediastream
 
+urlPrefix: https://www.w3.org/TR/mediacapture-streams/#; type: dfn; text: track set; url: track-set
+
 urlPrefix: https://www.w3.org/TR/mediacapture-streams/#; type: interface; text: MediaStreamTrack; url: mediastreamtrack
 
-urlPrefix: https://www.w3.org/TR/mediacapture-streams/#; type: method; text: onmute; url: widl-MediaStreamTrack-onmute
+urlPrefix: https://www.w3.org/TR/mediacapture-streams/#; type: method; text: onmute; url: dom-mediastreamtrack-onmute
 
 urlPrefix: https://www.w3.org/TR/mediacapture-streams/#; type: method; text: getUserMedia(); url: dom-mediadevices-getusermedia
 
-urlPrefix: https://www.w3.org/TR/mediacapture-streams/#; type: attribute; text: muted; url: widl-MediaStreamTrack-muted
+urlPrefix: https://www.w3.org/TR/mediacapture-streams/#; type: attribute; text: muted; url: dom-mediastreamtrack-muted
 
-urlPrefix: https://www.w3.org/TR/mediacapture-streams/#; type: attribute; text: enabled; url: widl-MediaStreamTrack-enabled
+urlPrefix: https://www.w3.org/TR/mediacapture-streams/#; type: attribute; text: enabled; url: dom-mediastreamtrack-enabled
+
+urlPrefix: https://www.w3.org/TR/mediacapture-streams/#; type: attribute; text: kind; url: dom-mediastreamtrack-kind
 
 urlPrefix: https://www.w3.org/TR/mediacapture-streams/#; type: enum-value; text: ended; url: idl-def-MediaStreamTrackState.ended
 

--- a/MediaRecorder.bs
+++ b/MediaRecorder.bs
@@ -116,22 +116,22 @@ interface MediaRecorder : EventTarget {
     </tbody>
   </table>
   </dd>
-  <dd algorithm="to construct a MediaRecorder">When the {{MediaRecorder()}}
+  <dd>When the {{MediaRecorder()}}
   constructor is invoked, the User Agent MUST run the following steps:
   <ol>
     <li>Let |recorder| be a newly constructed {{MediaRecorder}} object.</li>
     <li>Initialize |recorder|'s {{MediaRecorder/stream}} attribute to the
     constructor's first argument.</li>
-    <li>Let |recorder| have a <dfn>\[[constrainedMimeType]]</dfn> internal slot,
+    <li>Let |recorder| have a <dfn>\[[ConstrainedMimeType]]</dfn> internal slot,
     initialized to the empty string.</li>
-    <li>If the {{MediaRecorderOptions/mimeType}} member is present in the
-    constructor's second argument, set |recorder|'s [=[[constrainedMimeType]]=]
-    slot to the value of {{MediaRecorderOptions/mimeType}}.</li>
+    <li>Let |options| be the constructor's second argument.</li>
+    <li>Set |recorder|'s [=[[ConstrainedMimeType]]=] slot to the value of
+    |options|' {{MediaRecorderOptions/mimeType}} member, if it is present.</li>
     <li>If invoking [$is type supported$] with |recorder|'s
-    [=[[constrainedMimeType]]=] slot as its argument returns false, throw a
+    [=[[ConstrainedMimeType]]=] slot as its argument returns false, throw a
     {{NotSupportedError}} {{DOMException}} and abort these steps.</li>
     <li>Initialize |recorder|'s {{MediaRecorder/mimeType}} attribute to the
-    value of |recorder|'s [=[[constrainedMimeType]]=] slot.</li>
+    value of |recorder|'s [=[[ConstrainedMimeType]]=] slot.</li>
     <li>Initialize |recorder|'s {{MediaRecorder/state}} attribute to
     {{inactive}}.</li>
     <li>Return |recorder|.</li>
@@ -199,32 +199,34 @@ interface MediaRecorder : EventTarget {
     and fire events asynchronously.
   </div>
   <dt><dfn method for="MediaRecorder"><code>start(optional unsigned long timeslice)</code></dfn></dt>
-  <dd algorithm="to start a MediaRecorder">
+  <dd>
   When a {{MediaRecorder}} object&#8217;s {{start()}} method is invoked, the UA
   MUST run the following steps:
   <ol>
-    <li>Let <var>target</var> be the MediaRecorder context object.</li>
+    <li>Let |recorder| be the {{MediaRecorder}} object on which the method was
+    invoked.</li>
+
     <li>Let <var>timeslice</var> be the method's first argument, if provided,
     or <code>undefined</code>. </li>
 
-    <li>If {{state}} is not {{inactive}}, throw an {{InvalidStateError}}
-    {{DOMException}} and abort these steps.</li>
+    <li>If the value of |recorder|'s {{state}} attribute is not {{inactive}},
+    throw an {{InvalidStateError}} {{DOMException}} and abort these steps.</li>
 
-    <li>If the {{stream}}'s <a>isolation properties</a> disallow access
-    from this {{MediaRecorder}}, throw a {{SecurityError}} {{DOMException}} and
-    abort these steps.</li>
+    <li>If the <a>isolation properties</a> of |recorder|'s {{stream}} attribute
+    disallow access from |recorder|, throw a {{SecurityError}} {{DOMException}}
+    and abort these steps.</li>
 
-    <li>If the {{stream}} is {{inactive}}, throw a {{NotSupportedError}}
-    {{DOMException}} and abort these steps.</li>
+    <li>If |recorder|'s {{stream}} is {{inactive}}, throw a
+    {{NotSupportedError}} {{DOMException}} and abort these steps.</li>
 
-    <li>Let |tracks| be the set of {{live}} tracks in the {{stream}}'s
+    <li>Let |tracks| be the set of {{live}} tracks in |recorder|'s {{stream}}'s
     [=track set=].</li>
 
-    <li>If the [=[[constrainedMimeType]]=] slot specifies a media type,
+    <li>If the [=[[ConstrainedMimeType]]=] slot specifies a media type,
     container, or codec, then run the following sub steps:
     <ol>
-      <li>Constrain the configuration of the MediaRecorder to the media type,
-      container, and codec specified in the [=[[constrainedMimeType]]=]
+      <li>Constrain the configuration of |recorder| to the media type,
+      container, and codec specified in the [=[[ConstrainedMimeType]]=]
       slot.</li>
       <li>For each track in |tracks|, if the User Agent cannot record the track
       using the current configuration, then throw a {{NotSupportedError}}
@@ -232,22 +234,23 @@ interface MediaRecorder : EventTarget {
     </ol>
     </li>
 
-    <li>Let |extendedMimeType| be the value of the [=[[constrainedMimeType]]=]
-    slot.</li>
+    <li>Let |extendedMimeType| be the value of |recorder|'s
+    [=[[ConstrainedMimeType]]=] slot.</li>
 
     <li>Modify |extendedMimeType| by adding media type, subtype and codecs
     parameter reflecting the configuration used by the MediaRecorder to record
     all tracks in |tracks|, if not already present. This MAY include the
     profiles parameter [[RFC6381]] or further codec-specific parameters.</li>
 
-    <li>Set {{mimeType}} to |extendedMimeType|.</li>
+    <li>Set |recorder|'s {{mimeType}} attribute to |extendedMimeType|.</li>
 
-    <li>Set {{state}} to {{recording}}, and run the following steps in parallel:
+    <li>Set |recorder|'s {{state}} to {{recording}}, and run the following steps
+    in parallel:
     <ol>
       <li>Start recording all tracks in |tracks| using the {{MediaRecorder}}'s
       current configuration, and gather the data into a {{Blob}} <var>blob</var>
       and queue a task, using the DOM manipulation task source, to
-      <a>fire an event</a> named <a>start</a> at <var>target</var>, then return
+      <a>fire an event</a> named <a>start</a> at <var>recorder</var>, then return
       <code>undefined</code>.</li>
 
       <li>If at any point the {{stream}}'s <a>isolation properties</a> change so
@@ -256,14 +259,12 @@ interface MediaRecorder : EventTarget {
       and queue a task, using the DOM manipulation task source, that runs the
       following steps:
       <ol>
-        <li>Set {{mimeType}} to the value of the [=[[constrainedMimeType]]=]
-        slot.</li>
-        <li>Set {{state}} to {{inactive}}.</li>
+        <li>[$Reset the MediaRecorder$] with |recorder|.</li>
         <li><a>Fire an error event</a> named {{SecurityError}} at
-        <var>target</var>.</li>
+        <var>recorder</var>.</li>
         <li><a href="#to-fire-a-blob-event">Fire a blob event</a> named
-        <a>dataavailable</a> at <var>target</var> with <var>blob</var>.</li>
-        <li><a>Fire an event</a> named <a>stop</a> at <var>target</var>.</li>
+        <a>dataavailable</a> at <var>recorder</var> with <var>blob</var>.</li>
+        <li><a>Fire an event</a> named <a>stop</a> at <var>recorder</var>.</li>
       </ol>
       </li>
 
@@ -272,14 +273,12 @@ interface MediaRecorder : EventTarget {
       data that it has gathered, and queue a task, using the DOM manipulation
       task source, that runs the following steps:
       <ol>
-        <li>Set {{mimeType}} to the value of the [=[[constrainedMimeType]]=]
-        slot.</li>
-        <li>Set {{state}} to {{inactive}}.</li>
+        <li>[$Reset the MediaRecorder$] with |recorder|.</li>
         <li><a>Fire an error event</a> named {{InvalidModificationError}} at
-        <var>target</var>.</li>
+        <var>recorder</var>.</li>
         <li><a href="#to-fire-a-blob-event">Fire a blob event</a> named
-        <a>dataavailable</a> at <var>target</var> with <var>blob</var>.</li>
-        <li><a>Fire an event</a> named <a>stop</a> at <var>target</var>.</li>
+        <a>dataavailable</a> at <var>recorder</var> with <var>blob</var>.</li>
+        <li><a>Fire an event</a> named <a>stop</a> at <var>recorder</var>.</li>
       </ol>
       </li>
 
@@ -288,14 +287,12 @@ interface MediaRecorder : EventTarget {
       it MUST stop gathering data, and queue a task, using the DOM manipulation
       task source, that runs the following steps:
       <ol>
-        <li>Set {{mimeType}} to the value of the [=[[constrainedMimeType]]=]
-        slot.</li>
-        <li>Set {{state}} to {{inactive}}.</li>
+        <li>[$Reset the MediaRecorder$] with |recorder|.</li>
         <li><a>Fire an error event</a> named {{UnknownError}} at
-        <var>target</var>.</li>
+        <var>recorder</var>.</li>
         <li><a href="#to-fire-a-blob-event">Fire a blob event</a> named
-        <a>dataavailable</a> at <var>target</var> with <var>blob</var>.</li>
-        <li><a>Fire an event</a> named <a>stop</a> at <var>target</var>.</li>
+        <a>dataavailable</a> at <var>recorder</var> with <var>blob</var>.</li>
+        <li><a>Fire an event</a> named <a>stop</a> at <var>recorder</var>.</li>
       </ol>
       </li>
 
@@ -305,7 +302,7 @@ interface MediaRecorder : EventTarget {
       gathering data into a new {{Blob}} <var>blob</var>, and queue a task,
       using the DOM manipulation task source, that
       <a href="#to-fire-a-blob-event">fires a blob event</a> named
-      <a>dataavailable</a> at <var>target</var> with <var>blob</var>.
+      <a>dataavailable</a> at <var>recorder</var> with <var>blob</var>.
 
       Note that an <code>undefined</code> value of <var>timeslice</var> will
       be understood as the largest <code>long</code> value.</li>
@@ -314,13 +311,11 @@ interface MediaRecorder : EventTarget {
       queue a task, using the DOM manipulation task source, that runs the
       following steps:
       <ol>
-        <li>Set {{mimeType}} to the value of the [=[[constrainedMimeType]]=]
-        slot.</li>
-        <li>Set {{state}} to {{inactive}}.</li>
+        <li>[$Reset the MediaRecorder$] with |recorder|.</li>
         <li><a href="#to-fire-a-blob-event">Fire a blob event</a> named
-        <a>dataavailable</a> at <var>target</var> with <var>blob</var>.</li>
+        <a>dataavailable</a> at <var>recorder</var> with <var>blob</var>.</li>
         <li><a>Fire an event</a> named <a>stop</a> at
-        <var>target</var>.</li>
+        <var>recorder</var>.</li>
       </ol>
       </li>
 
@@ -340,6 +335,14 @@ interface MediaRecorder : EventTarget {
   <p> If any Track within the {{MediaStream}} is {{muted}} or not {{enabled}} at
   any time, the UA will only record black frames or silence since that is the
   content produced by the Track.</p>
+
+  <p>The <dfn abstract-op>Reset the MediaRecorder</dfn> algorithm given a
+  |recorder|, is as follows:</p>
+  <ol>
+    <li>Set |recorder|'s {{mimeType}} attribute to the value of the
+    [=[[ConstrainedMimeType]]=] slot.</li>
+    <li>Set |recorder|'s {{state}} attribute to {{inactive}}.</li>
+  </ol>
 
   <table class="parameters">
     <tbody>
@@ -367,18 +370,19 @@ interface MediaRecorder : EventTarget {
   When a {{MediaRecorder}} object&#8217;s {{stop()}} method is invoked, the UA
   MUST run the following steps:
   <ol>
-    <li>If {{state}} is {{inactive}}, abort these steps.</li>
-    <li>Set {{mimeType}} to the value of the [=[[constrainedMimeType]]=]
-    slot.</li>
-    <li>Set {{state}} to {{inactive}}, and queue a
-    task, using the DOM manipulation task source, that runs the following steps:
+    <li>Let |recorder| be the {{MediaRecorder}} object on which the method was
+    invoked.</li>
+    <li>If |recorder|'s {{state}} attribute is {{inactive}}, abort these
+    steps.</li>
+    <li>[$Reset the MediaRecorder$] with |recorder|.</li>
+    <li>Queue a task, using the DOM manipulation task source, that runs the
+    following steps:
     <ol>
       <li>Stop gathering data.</li>
-      <li>Let <var>blob</var> be the Blob of collected data so far and
-      let <var>target</var> be the MediaRecorder context object, then
+      <li>Let <var>blob</var> be the Blob of collected data so far, then
       <a href="#to-fire-a-blob-event">fire a blob event</a> named
-      <a>dataavailable</a> at <var>target</var> with <var>blob</var>.</li>
-      <li><a>Fire an event</a> named <a>stop</a> at <var>target</var>.</li>
+      <a>dataavailable</a> at <var>recorder</var> with <var>blob</var>.</li>
+      <li><a>Fire an event</a> named <a>stop</a> at <var>recorder</var>.</li>
     </ol>
     </li>
     <li>return <code>undefined</code>.</li>

--- a/MediaRecorder.bs
+++ b/MediaRecorder.bs
@@ -119,17 +119,19 @@ interface MediaRecorder : EventTarget {
   <dd>When the {{MediaRecorder()}}
   constructor is invoked, the User Agent MUST run the following steps:
   <ol>
+    <li>Let |stream| be the constructor's first argument.</li>
+    <li>Let |options| be the constructor's second argument.</li>
+    <li>If {{MediaRecorderOptions/mimeType}} is present in |options|, and
+    invoking [$is type supported$] with |options|'
+    {{MediaRecorderOptions/mimeType}} member as its argument returns false,
+    throw a {{NotSupportedError}} {{DOMException}} and abort these steps.</li>
     <li>Let |recorder| be a newly constructed {{MediaRecorder}} object.</li>
-    <li>Initialize |recorder|'s {{MediaRecorder/stream}} attribute to the
-    constructor's first argument.</li>
     <li>Let |recorder| have a <dfn>\[[ConstrainedMimeType]]</dfn> internal slot,
     initialized to the empty string.</li>
-    <li>Let |options| be the constructor's second argument.</li>
     <li>Set |recorder|'s [=[[ConstrainedMimeType]]=] slot to the value of
     |options|' {{MediaRecorderOptions/mimeType}} member, if it is present.</li>
-    <li>If invoking [$is type supported$] with |recorder|'s
-    [=[[ConstrainedMimeType]]=] slot as its argument returns false, throw a
-    {{NotSupportedError}} {{DOMException}} and abort these steps.</li>
+    <li>Initialize |recorder|'s {{MediaRecorder/stream}} attribute to
+    |stream|.</li>
     <li>Initialize |recorder|'s {{MediaRecorder/mimeType}} attribute to the
     value of |recorder|'s [=[[ConstrainedMimeType]]=] slot.</li>
     <li>Initialize |recorder|'s {{MediaRecorder/state}} attribute to
@@ -209,18 +211,20 @@ interface MediaRecorder : EventTarget {
     <li>Let <var>timeslice</var> be the method's first argument, if provided,
     or <code>undefined</code>. </li>
 
+    <li>Let |stream| be the value of |recorder|'s {{stream}} attribute.</li>
+
+    <li>Let |tracks| be the set of {{live}} tracks in |stream|'s
+    [=track set=].</li>
+
     <li>If the value of |recorder|'s {{state}} attribute is not {{inactive}},
     throw an {{InvalidStateError}} {{DOMException}} and abort these steps.</li>
 
-    <li>If the <a>isolation properties</a> of |recorder|'s {{stream}} attribute
-    disallow access from |recorder|, throw a {{SecurityError}} {{DOMException}}
-    and abort these steps.</li>
+    <li>If the <a>isolation properties</a> of |stream| disallow access from
+    |recorder|, throw a {{SecurityError}} {{DOMException}} and abort these
+    steps.</li>
 
-    <li>If |recorder|'s {{stream}} is {{inactive}}, throw a
-    {{NotSupportedError}} {{DOMException}} and abort these steps.</li>
-
-    <li>Let |tracks| be the set of {{live}} tracks in |recorder|'s {{stream}}'s
-    [=track set=].</li>
+    <li>If |stream| is {{inactive}}, throw a {{NotSupportedError}}
+    {{DOMException}} and abort these steps.</li>
 
     <li>If the [=[[ConstrainedMimeType]]=] slot specifies a media type,
     container, or codec, then run the following sub steps:
@@ -253,13 +257,13 @@ interface MediaRecorder : EventTarget {
       <a>fire an event</a> named <a>start</a> at <var>recorder</var>, then return
       <code>undefined</code>.</li>
 
-      <li>If at any point the {{stream}}'s <a>isolation properties</a> change so
+      <li>If at any point |stream|'s <a>isolation properties</a> change so
       that {{MediaRecorder}} is no longer allowed access to it, the UA MUST
       immediately stop gathering data, discard any data that it has gathered,
       and queue a task, using the DOM manipulation task source, that runs the
       following steps:
       <ol>
-        <li>[$Reset the MediaRecorder$] with |recorder|.</li>
+        <li>[$Inactivate the recorder$] with |recorder|.</li>
         <li><a>Fire an error event</a> named {{SecurityError}} at
         <var>recorder</var>.</li>
         <li><a href="#to-fire-a-blob-event">Fire a blob event</a> named
@@ -268,12 +272,12 @@ interface MediaRecorder : EventTarget {
       </ol>
       </li>
 
-      <li>If at any point, a track is added to or removed from the {{stream}}'s
+      <li>If at any point, a track is added to or removed from |stream|'s
       [=track set=], the UA MUST immediately stop gathering data, discard any
       data that it has gathered, and queue a task, using the DOM manipulation
       task source, that runs the following steps:
       <ol>
-        <li>[$Reset the MediaRecorder$] with |recorder|.</li>
+        <li>[$Inactivate the recorder$] with |recorder|.</li>
         <li><a>Fire an error event</a> named {{InvalidModificationError}} at
         <var>recorder</var>.</li>
         <li><a href="#to-fire-a-blob-event">Fire a blob event</a> named
@@ -283,11 +287,11 @@ interface MediaRecorder : EventTarget {
       </li>
 
       <li>If the UA at any point is unable to continue gathering data for
-      reasons other than <a>isolation properties</a> or stream [=track set=],
-      it MUST stop gathering data, and queue a task, using the DOM manipulation
-      task source, that runs the following steps:
+      reasons other than <a>isolation properties</a> or |stream|'s
+      [=track set=], it MUST stop gathering data, and queue a task, using the
+      DOM manipulation task source, that runs the following steps:
       <ol>
-        <li>[$Reset the MediaRecorder$] with |recorder|.</li>
+        <li>[$Inactivate the recorder$] with |recorder|.</li>
         <li><a>Fire an error event</a> named {{UnknownError}} at
         <var>recorder</var>.</li>
         <li><a href="#to-fire-a-blob-event">Fire a blob event</a> named
@@ -311,7 +315,7 @@ interface MediaRecorder : EventTarget {
       queue a task, using the DOM manipulation task source, that runs the
       following steps:
       <ol>
-        <li>[$Reset the MediaRecorder$] with |recorder|.</li>
+        <li>[$Inactivate the recorder$] with |recorder|.</li>
         <li><a href="#to-fire-a-blob-event">Fire a blob event</a> named
         <a>dataavailable</a> at <var>recorder</var> with <var>blob</var>.</li>
         <li><a>Fire an event</a> named <a>stop</a> at
@@ -336,7 +340,7 @@ interface MediaRecorder : EventTarget {
   any time, the UA will only record black frames or silence since that is the
   content produced by the Track.</p>
 
-  <p>The <dfn abstract-op>Reset the MediaRecorder</dfn> algorithm given a
+  <p>The <dfn abstract-op>Inactivate the recorder</dfn> algorithm given a
   |recorder|, is as follows:</p>
   <ol>
     <li>Set |recorder|'s {{mimeType}} attribute to the value of the
@@ -374,7 +378,7 @@ interface MediaRecorder : EventTarget {
     invoked.</li>
     <li>If |recorder|'s {{state}} attribute is {{inactive}}, abort these
     steps.</li>
-    <li>[$Reset the MediaRecorder$] with |recorder|.</li>
+    <li>[$Inactivate the recorder$] with |recorder|.</li>
     <li>Queue a task, using the DOM manipulation task source, that runs the
     following steps:
     <ol>

--- a/MediaRecorder.bs
+++ b/MediaRecorder.bs
@@ -122,16 +122,16 @@ interface MediaRecorder : EventTarget {
     <li>Let |recorder| be a newly constructed {{MediaRecorder}} object.</li>
     <li>Initialize |recorder|'s {{MediaRecorder/stream}} attribute to the
     constructor's first argument.</li>
-    <li>Each {{MediaRecorder}} has an internal <dfn>constrainedMimeType</dfn>
-    property that is initially set to the empty string.</li>
+    <li>Let |recorder| have a <dfn>\[[constrainedMimeType]]</dfn> internal slot,
+    initialized to the empty string.</li>
     <li>If the {{MediaRecorderOptions/mimeType}} member is present in the
-    constructor's second argument, set the [=constrainedMimeType=] internal
-    property to the value of {{MediaRecorderOptions/mimeType}}.</li>
-    <li>If invoking [$is type supported$] with the [=constrainedMimeType=]
-    internal property as its argument returns false, throw a
+    constructor's second argument, set |recorder|'s [=[[constrainedMimeType]]=]
+    slot to the value of {{MediaRecorderOptions/mimeType}}.</li>
+    <li>If invoking [$is type supported$] with |recorder|'s
+    [=[[constrainedMimeType]]=] slot as its argument returns false, throw a
     {{NotSupportedError}} {{DOMException}} and abort these steps.</li>
     <li>Initialize |recorder|'s {{MediaRecorder/mimeType}} attribute to the
-    [=constrainedMimeType=] internal property.</li>
+    value of |recorder|'s [=[[constrainedMimeType]]=] slot.</li>
     <li>Initialize |recorder|'s {{MediaRecorder/state}} attribute to
     {{inactive}}.</li>
     <li>Return |recorder|.</li>
@@ -220,19 +220,20 @@ interface MediaRecorder : EventTarget {
     <li>Let |tracks| be the set of {{live}} tracks in the {{stream}}'s
     [=track set=].</li>
 
-    <li>If the [=constrainedMimeType=] internal property specifies a media type,
+    <li>If the [=[[constrainedMimeType]]=] slot specifies a media type,
     container, or codec, then run the following sub steps:
     <ol>
       <li>Constrain the configuration of the MediaRecorder to the media type,
-      container, and codec specified in [=constrainedMimeType=].</li>
+      container, and codec specified in the [=[[constrainedMimeType]]=]
+      slot.</li>
       <li>For each track in |tracks|, if the User Agent cannot record the track
       using the current configuration, then throw a {{NotSupportedError}}
       {{DOMException}} and abort all steps.</li>
     </ol>
     </li>
 
-    <li>Let |extendedMimeType| be the value of the [=constrainedMimeType=]
-    internal property.</li>
+    <li>Let |extendedMimeType| be the value of the [=[[constrainedMimeType]]=]
+    slot.</li>
 
     <li>Modify |extendedMimeType| by adding media type, subtype and codecs
     parameter reflecting the configuration used by the MediaRecorder to record
@@ -255,8 +256,8 @@ interface MediaRecorder : EventTarget {
       and queue a task, using the DOM manipulation task source, that runs the
       following steps:
       <ol>
-        <li>Set {{mimeType}} to the value of the [=constrainedMimeType=]
-        internal property.</li>
+        <li>Set {{mimeType}} to the value of the [=[[constrainedMimeType]]=]
+        slot.</li>
         <li>Set {{state}} to {{inactive}}.</li>
         <li><a>Fire an error event</a> named {{SecurityError}} at
         <var>target</var>.</li>
@@ -271,8 +272,8 @@ interface MediaRecorder : EventTarget {
       data that it has gathered, and queue a task, using the DOM manipulation
       task source, that runs the following steps:
       <ol>
-        <li>Set {{mimeType}} to the value of the [=constrainedMimeType=]
-        internal property.</li>
+        <li>Set {{mimeType}} to the value of the [=[[constrainedMimeType]]=]
+        slot.</li>
         <li>Set {{state}} to {{inactive}}.</li>
         <li><a>Fire an error event</a> named {{InvalidModificationError}} at
         <var>target</var>.</li>
@@ -287,8 +288,8 @@ interface MediaRecorder : EventTarget {
       it MUST stop gathering data, and queue a task, using the DOM manipulation
       task source, that runs the following steps:
       <ol>
-        <li>Set {{mimeType}} to the value of the [=constrainedMimeType=]
-        internal property.</li>
+        <li>Set {{mimeType}} to the value of the [=[[constrainedMimeType]]=]
+        slot.</li>
         <li>Set {{state}} to {{inactive}}.</li>
         <li><a>Fire an error event</a> named {{UnknownError}} at
         <var>target</var>.</li>
@@ -313,8 +314,8 @@ interface MediaRecorder : EventTarget {
       queue a task, using the DOM manipulation task source, that runs the
       following steps:
       <ol>
-        <li>Set {{mimeType}} to the value of the [=constrainedMimeType=]
-        internal property.</li>
+        <li>Set {{mimeType}} to the value of the [=[[constrainedMimeType]]=]
+        slot.</li>
         <li>Set {{state}} to {{inactive}}.</li>
         <li><a href="#to-fire-a-blob-event">Fire a blob event</a> named
         <a>dataavailable</a> at <var>target</var> with <var>blob</var>.</li>
@@ -367,8 +368,8 @@ interface MediaRecorder : EventTarget {
   MUST run the following steps:
   <ol>
     <li>If {{state}} is {{inactive}}, abort these steps.</li>
-    <li>Set {{mimeType}} to the value of the [=constrainedMimeType=]
-    internal property.</li>
+    <li>Set {{mimeType}} to the value of the [=[[constrainedMimeType]]=]
+    slot.</li>
     <li>Set {{state}} to {{inactive}}, and queue a
     task, using the DOM manipulation task source, that runs the following steps:
     <ol>


### PR DESCRIPTION
Fixes #170.

This lets the mimeType passed to a recorder on construction be
constraining, to force a recorder to use a certain container or codecs.
It also updates a recorder's mimeType while it's recording, so the
application can be aware of the decisions the UA makes for it.