### PR TITLE
Input width, height MUST be recorded and playable

### DIFF
--- a/MediaRecorder.bs
+++ b/MediaRecorder.bs
@@ -284,6 +284,13 @@ interface MediaRecorder : EventTarget {
   (because of {{timeslice}} or {{requestData()}}), the individual Blobs need not
   be playable, but the combination of all the Blobs from a completed recording
   MUST be playable.</p>
+  
+  <p>The UA MUST record {{MediaRecorder/stream}} in such a way that the original
+  video Track(s) width and height can be retrieved at playback time. The {{Blob}}
+  containing entire recording returned when the recording finishes or smaller 
+  buffers of data returned at regular intervals containing the combination of all 
+  the original video Track(s) width and height MUST playback the input video Track(s) 
+  width and height.</p>
 
   <p> If any Track within the {{MediaStream}} is {{muted}} or not {{enabled}} at
   any time, the UA will only record black frames or silence since that is the


### PR DESCRIPTION
Input MediaStreamTrack of kind "video" width and height MUST be recorded and playable.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/guest271314/mediacapture-record/pull/172.html" title="Last updated on Feb 15, 2021, 7:32 AM UTC (1ea1b20)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/mediacapture-record/172/963bfbb...guest271314:1ea1b20.html" title="Last updated on Feb 15, 2021, 7:32 AM UTC (1ea1b20)">Diff</a>