### PR TITLE
Defer deciding codec until "onstart" fires

### DIFF
--- a/MediaRecorder.bs
+++ b/MediaRecorder.bs
@@ -276,7 +276,7 @@ interface MediaRecorder : EventTarget {
     <li>Set |recorder|'s {{state}} to {{recording}}, and run the following steps
     in parallel:
     <ol>
-      <li>The User Agent MUST decide the |recorder|'s configuration for
+      <li>Let the User Agent specify the |recorder|'s configuration for
       recording all the tracks in |tracks|, given its current constraints. If
       track data is available, the User Agent MAY take the content into account
       when making this decision as long as this does not violate how the

--- a/MediaRecorder.bs
+++ b/MediaRecorder.bs
@@ -255,9 +255,9 @@ interface MediaRecorder : EventTarget {
     <li>Let |extendedMimeType| be the value of |recorder|'s
     [=[[ConstrainedMimeType]]=] slot.</li>
 
-    <li>If |extendedMimeType| is empty, the User Agent MUST modify it by adding
-    media type, subtype and codecs parameter reflecting the configuration used
-    by the MediaRecorder to record all tracks in |tracks|, if not already
+    <li>If |extendedMimeType| is not empty, the User Agent MUST modify it by
+    adding media type, subtype and codecs parameter reflecting the configuration
+    used by the MediaRecorder to record all tracks in |tracks|, if not already
     present. This MAY include the profiles parameter [[RFC6381]] or further
     codec-specific parameters.</li>
     <div class="note">
@@ -310,11 +310,11 @@ interface MediaRecorder : EventTarget {
       </ol>
       <div class="note">
         By looking at the content of the tracks when recording start, the User
-        Agent could take frame information into account. If the MediaStreamTrack
-        is a remote track sourced from an RTCPeerConnection, the User Agent is
-        allowed to pick the same codec that the source RTP stream uses, which
-        may allow the User Agent to avoid the cost of re-encoding by recording
-        the raw encoded frames.
+        Agent could take frame information into account. For example, if the
+        MediaStreamTrack is a remote track sourced from an RTCPeerConnection,
+        the User Agent is allowed to pick the same codec that the source RTP
+        stream uses, which may allow the User Agent to avoid the cost of
+        re-encoding by recording the raw encoded frames.
       </div>
       </li>
 

--- a/MediaRecorder.bs
+++ b/MediaRecorder.bs
@@ -252,23 +252,6 @@ interface MediaRecorder : EventTarget {
     </ol>
     </li>
 
-    <li>Let |extendedMimeType| be the value of |recorder|'s
-    [=[[ConstrainedMimeType]]=] slot.</li>
-
-    <li>If |extendedMimeType| is not empty, the User Agent MUST modify it by
-    adding media type, subtype and codecs parameter reflecting the configuration
-    used by the MediaRecorder to record all tracks in |tracks|, if not already
-    present. This MAY include the profiles parameter [[RFC6381]] or further
-    codec-specific parameters.</li>
-    <div class="note">
-      In the case that |extendedMimeType| is empty, the mimeType will be updated
-      when "onstart" fires. This allows the User Agent to defer configurating
-      which codec to use until the tracks deliver frames. This allows the User
-      Agent to make optimizations based on the source of the track.
-    </div>
-
-    <li>Set |recorder|'s {{mimeType}} attribute to |extendedMimeType|.</li>
-
     <li>If |recorder|'s [=[[ConstrainedBitsPerSecond]]=] slot is not
     <code>undefined</code>, set |recorder|'s {{videoBitsPerSecond}} and
     {{audioBitsPerSecond}} attributes to values the User Agent deems reasonable
@@ -293,18 +276,18 @@ interface MediaRecorder : EventTarget {
     <li>Set |recorder|'s {{state}} to {{recording}}, and run the following steps
     in parallel:
     <ol>
-      <li>As soon as data is available on all tracks in |tracks|, if the
-      |recorder|'s current configuration does not already specify the codecs to
-      use, the User Agent MUST specify this. The User Agent MAY take the content
-      of the first frame into account when making this decision. The User Agent
-      MUST then start recording with the configuration and gather the data into
-      a {{Blob}} <var>blob</var>. As soon as recording starts, queue a task,
-      using the DOM manipulation task source, to run the following steps:
+      <li>As soon as data is available on all tracks in |tracks|, the User Agent
+      MUST specify the |recorder|'s configuration for recording the tracks, if
+      not already specified. The User Agent MAY take the content of the first
+      frame into account when making this decision. The User Agent MUST then
+      start recording with this configuration and gather the data into a
+      {{Blob}} <var>blob</var>. As soon as recording starts, queue a task, using
+      the DOM manipulation task source, to run the following steps:
       <ol>
-        <li>Set |recorder|'s {{mimeType}} to reflect the current
-        configuration, including media type, subtype and codecs parameter. This
-        MAY include the profiles parameters [[RFC6381]] or further
-        codec-specific parameters.</li>
+        <li>Set |recorder|'s {{mimeType}} to reflect the configuration,
+        including media type, subtype and codecs parameter. This MAY include the
+        profiles parameters [[RFC6381]] or further codec-specific
+        parameters.</li>
         <li><a>Fire an event</a> named <a>start</a> at <var>recorder</var>, then
         return <code>undefined</code>.</li>
       </ol>

--- a/MediaRecorder.bs
+++ b/MediaRecorder.bs
@@ -276,12 +276,11 @@ interface MediaRecorder : EventTarget {
     <li>Set |recorder|'s {{state}} to {{recording}}, and run the following steps
     in parallel:
     <ol>
-      <li>Start recording all tracks in |tracks| using the |recorder|'s current
-      configuration and gather the data into a {{Blob}} <var>blob</var>. If the
-      container and codecs to use for the recording have not yet been fully
-      specified, the User Agent specifies them in |recorder|'s current
+      <li>If the container and codecs to use for the recording have not yet been
+      fully specified, the User Agent specifies them in |recorder|'s current
       configuration. The User Agent MAY take the sources of the tracks in
-      |tracks| into account when deciding which container and codecs to use.
+      |tracks| into account when deciding which container and codecs to
+      use.
       <div class="note">
         By looking at the sources of the tracks in |tracks| when recording
         starts, the User Agent could choose a configuration that avoids
@@ -289,11 +288,13 @@ interface MediaRecorder : EventTarget {
         remote track sourced from an RTCPeerConnection, the User Agent could
         pick the same codec as is used for the MediaStreamTrack's RTP stream,
         should it be known. However, if the codec of the RTP stream changes
-        while recording the User Agent has to be prepared to re-encode it to
+        while recording, the User Agent has to be prepared to re-encode it to
         avoid interruptions.
       </div>
-      Queue a task, using the DOM manipulation task source, to run the following
-      steps:
+      </li>
+      <li>Start recording all tracks in |tracks| using the |recorder|'s current
+      configuration and gather the data into a {{Blob}} <var>blob</var>. Queue a
+      task, using the DOM manipulation task source, to run the following steps:
       <ol>
         <li>Let |extendedMimeType| be the value of |recorder|'s
         [=[[ConstrainedMimeType]]=] slot.</li>

--- a/MediaRecorder.bs
+++ b/MediaRecorder.bs
@@ -276,23 +276,24 @@ interface MediaRecorder : EventTarget {
     <li>Set |recorder|'s {{state}} to {{recording}}, and run the following steps
     in parallel:
     <ol>
-      <li>Let the User Agent specify the |recorder|'s configuration for
-      recording all the tracks in |tracks|, given its current constraints. If
-      track data is available, the User Agent MAY take the content into account
-      when making this decision as long as this does not violate how the
-      configuration has previously been constrained (see earlier steps).</li>
-      <div class="note">
-        By looking at the content of the tracks when recording start, the User
-        Agent could take frame information into account. For example, if the
-        MediaStreamTrack is a remote track sourced from an RTCPeerConnection,
-        the User Agent is allowed to pick the same codec that the source RTP
-        stream uses, which may allow the User Agent to avoid the cost of
-        re-encoding by recording the raw encoded frames.
-      </div>
       <li>Start recording all tracks in |tracks| using the |recorder|'s current
-      configuration and gather the data into a {{Blob}} <var>blob</var>. As soon
-      as recording starts, queue a task, using the DOM manipulation task source,
-      to run the following steps:
+      configuration and gather the data into a {{Blob}} <var>blob</var>. If the
+      codec or container has not yet been specified, the User Agent specifies
+      it. The User Agent MAY take the sources of the |tracks| into account when
+      making this decision as long as it does not violate the current
+      configuration.
+      <div class="note">
+        By looking at the sources of the tracks in |tracks| when recording
+        starts, the User Agent could choose a configuration that avoids
+        re-encoding track content. For example, if the MediaStreamTrack is a
+        remote track sourced from an RTCPeerConnection, the User Agent could
+        pick the same codec as is used for the MediaStreamTrack's RTP stream,
+        should it be known. However, if the codec of the RTP stream changes
+        while recording the User Agent have to be prepared to re-encode it to
+        avoid interruptions.
+      </div>
+      Queue a task, using the DOM manipulation task source, to run the following
+      steps:
       <ol>
         <li>Let |extendedMimeType| be the value of |recorder|'s
         [=[[ConstrainedMimeType]]=] slot.</li>

--- a/MediaRecorder.bs
+++ b/MediaRecorder.bs
@@ -276,21 +276,11 @@ interface MediaRecorder : EventTarget {
     <li>Set |recorder|'s {{state}} to {{recording}}, and run the following steps
     in parallel:
     <ol>
-      <li>As soon as data is available on all tracks in |tracks|, the User Agent
-      MUST specify the |recorder|'s configuration for recording the tracks, if
-      not already specified. The User Agent MAY take the content of the first
-      frame into account when making this decision. The User Agent MUST then
-      start recording with this configuration and gather the data into a
-      {{Blob}} <var>blob</var>. As soon as recording starts, queue a task, using
-      the DOM manipulation task source, to run the following steps:
-      <ol>
-        <li>Set |recorder|'s {{mimeType}} to reflect the configuration,
-        including media type, subtype and codecs parameter. This MAY include the
-        profiles parameters [[RFC6381]] or further codec-specific
-        parameters.</li>
-        <li><a>Fire an event</a> named <a>start</a> at <var>recorder</var>, then
-        return <code>undefined</code>.</li>
-      </ol>
+      <li>The User Agent MUST decide the |recorder|'s configuration for
+      recording all the tracks in |tracks|, given its current constraints. If
+      track data is available, the User Agent MAY take the content into account
+      when making this decision as long as this does not violate how the
+      configuration has previously been constrained (see earlier steps).</li>
       <div class="note">
         By looking at the content of the tracks when recording start, the User
         Agent could take frame information into account. For example, if the
@@ -299,6 +289,21 @@ interface MediaRecorder : EventTarget {
         stream uses, which may allow the User Agent to avoid the cost of
         re-encoding by recording the raw encoded frames.
       </div>
+      <li>Start recording all tracks in |tracks| using the |recorder|'s current
+      configuration and gather the data into a {{Blob}} <var>blob</var>. As soon
+      as recording starts, queue a task, using the DOM manipulation task source,
+      to run the following steps:
+      <ol>
+        <li>Let |extendedMimeType| be the value of |recorder|'s
+        [=[[ConstrainedMimeType]]=] slot.</li>
+        <li>Modify |extendedMimeType| by adding media type, subtype and codecs
+        parameter reflecting the configuration used by the MediaRecorder to
+        record all tracks in |tracks|, if not already present. This MAY include
+        the profiles parameter [[RFC6381]] or further codec-specific
+        parameters.</li>
+        <li>Set |recorder|'s {{mimeType}} attribute to |extendedMimeType|.</li>
+        <li><a>Fire an event</a> named <a>start</a> at |recorder|.</li>
+      </ol>
       </li>
 
       <li>If at any point |stream|'s <a>isolation properties</a> change so

--- a/MediaRecorder.bs
+++ b/MediaRecorder.bs
@@ -289,7 +289,7 @@ interface MediaRecorder : EventTarget {
         remote track sourced from an RTCPeerConnection, the User Agent could
         pick the same codec as is used for the MediaStreamTrack's RTP stream,
         should it be known. However, if the codec of the RTP stream changes
-        while recording the User Agent have to be prepared to re-encode it to
+        while recording the User Agent has to be prepared to re-encode it to
         avoid interruptions.
       </div>
       Queue a task, using the DOM manipulation task source, to run the following

--- a/MediaRecorder.bs
+++ b/MediaRecorder.bs
@@ -278,10 +278,10 @@ interface MediaRecorder : EventTarget {
     <ol>
       <li>Start recording all tracks in |tracks| using the |recorder|'s current
       configuration and gather the data into a {{Blob}} <var>blob</var>. If the
-      codec or container has not yet been specified, the User Agent specifies
-      it. The User Agent MAY take the sources of the |tracks| into account when
-      making this decision as long as it does not violate the current
-      configuration.
+      container and codecs to use for the recording have not yet been fully
+      specified, the User Agent specifies them in |recorder|'s current
+      configuration. The User Agent MAY take the sources of the tracks in
+      |tracks| into account when deciding which container and codecs to use.
       <div class="note">
         By looking at the sources of the tracks in |tracks| when recording
         starts, the User Agent could choose a configuration that avoids

--- a/MediaRecorder.bs
+++ b/MediaRecorder.bs
@@ -255,18 +255,16 @@ interface MediaRecorder : EventTarget {
     <li>Let |extendedMimeType| be the value of |recorder|'s
     [=[[ConstrainedMimeType]]=] slot.</li>
 
-    <li>Modify |extendedMimeType| by adding media type, subtype and codecs
-    parameter reflecting the configuration used by the MediaRecorder to record
-    all tracks in |tracks|, if not already present. This MAY include the
-    profiles parameter [[RFC6381]] or further codec-specific parameters. If
-    |extendedMimeType| did not already have a codec specified, the User Agent
-    MAY defer deciding which codec and parameters to use until recording has
-    started, in which case |extendedMimeType| will be missing this
-    information.</li>
+    <li>If |extendedMimeType| is empty, the User Agent MUST modify it by adding
+    media type, subtype and codecs parameter reflecting the configuration used
+    by the MediaRecorder to record all tracks in |tracks|, if not already
+    present. This MAY include the profiles parameter [[RFC6381]] or further
+    codec-specific parameters.</li>
     <div class="note">
-      Deferring configurating which codec to use allows the User Agent to make
-      optimizations based on the source of the track. The mimeType is guaranteed
-      to be contain codec and parameter information when "onstart" fires.
+      In the case that |extendedMimeType| is empty, the mimeType will be updated
+      when "onstart" fires. This allows the User Agent to defer configurating
+      which codec to use until the tracks deliver frames. This allows the User
+      Agent to make optimizations based on the source of the track.
     </div>
 
     <li>Set |recorder|'s {{mimeType}} attribute to |extendedMimeType|.</li>
@@ -296,27 +294,27 @@ interface MediaRecorder : EventTarget {
     in parallel:
     <ol>
       <li>As soon as data is available on all tracks in |tracks|, if the
-      |recorder|'s current configuration does not already specify the codec and
-      parameters to use, the User Agent MUST specify this. The User Agent MAY
-      take the content of the first frame into account when making this
-      decision. The User Agent MUST then start recording with the configuration
-      and gather the data into a {{Blob}} <var>blob</var>. As soon as recording
-      starts, queue a task, using the DOM manipulation task source, to run the
-      following steps:
+      |recorder|'s current configuration does not already specify the codecs to
+      use, the User Agent MUST specify this. The User Agent MAY take the content
+      of the first frame into account when making this decision. The User Agent
+      MUST then start recording with the configuration and gather the data into
+      a {{Blob}} <var>blob</var>. As soon as recording starts, queue a task,
+      using the DOM manipulation task source, to run the following steps:
       <ol>
         <li>Set |recorder|'s {{mimeType}} to reflect the current
-        configuration, including codec and parameter information.</li>
+        configuration, including media type, subtype and codecs parameter. This
+        MAY include the profiles parameters [[RFC6381]] or further
+        codec-specific parameters.</li>
         <li><a>Fire an event</a> named <a>start</a> at <var>recorder</var>, then
         return <code>undefined</code>.</li>
       </ol>
       <div class="note">
         By looking at the content of the tracks when recording start, the User
-        Agent could take frame information into account such as if the video is
-        high or low resolution. If the MediaStreamTrack is a remote track
-        sourced from an RTCPeerConnection, the User Agent is allowed to pick the
-        same codec that the source RTP stream uses, which may allow the User
-        Agent to avoid the cost of re-encoding by recording the raw encoded
-        frames.
+        Agent could take frame information into account. If the MediaStreamTrack
+        is a remote track sourced from an RTCPeerConnection, the User Agent is
+        allowed to pick the same codec that the source RTP stream uses, which
+        may allow the User Agent to avoid the cost of re-encoding by recording
+        the raw encoded frames.
       </div>
       </li>
 

--- a/MediaRecorder.bs
+++ b/MediaRecorder.bs
@@ -258,7 +258,16 @@ interface MediaRecorder : EventTarget {
     <li>Modify |extendedMimeType| by adding media type, subtype and codecs
     parameter reflecting the configuration used by the MediaRecorder to record
     all tracks in |tracks|, if not already present. This MAY include the
-    profiles parameter [[RFC6381]] or further codec-specific parameters.</li>
+    profiles parameter [[RFC6381]] or further codec-specific parameters. If
+    |extendedMimeType| did not already have a codec specified, the User Agent
+    MAY defer deciding which codec and parameters to use until recording has
+    started, in which case |extendedMimeType| will be missing this
+    information.</li>
+    <div class="note">
+      Deferring configurating which codec to use allows the User Agent to make
+      optimizations based on the source of the track. The mimeType is guaranteed
+      to be contain codec and parameter information when "onstart" fires.
+    </div>
 
     <li>Set |recorder|'s {{mimeType}} attribute to |extendedMimeType|.</li>
 
@@ -286,11 +295,30 @@ interface MediaRecorder : EventTarget {
     <li>Set |recorder|'s {{state}} to {{recording}}, and run the following steps
     in parallel:
     <ol>
-      <li>Start recording all tracks in |tracks| using the {{MediaRecorder}}'s
-      current configuration, and gather the data into a {{Blob}} <var>blob</var>
-      and queue a task, using the DOM manipulation task source, to
-      <a>fire an event</a> named <a>start</a> at <var>recorder</var>, then return
-      <code>undefined</code>.</li>
+      <li>As soon as data is available on all tracks in |tracks|, if the
+      |recorder|'s current configuration does not already specify the codec and
+      parameters to use, the User Agent MUST specify this. The User Agent MAY
+      take the content of the first frame into account when making this
+      decision. The User Agent MUST then start recording with the configuration
+      and gather the data into a {{Blob}} <var>blob</var>. As soon as recording
+      starts, queue a task, using the DOM manipulation task source, to run the
+      following steps:
+      <ol>
+        <li>Set |recorder|'s {{mimeType}} to reflect the current
+        configuration, including codec and parameter information.</li>
+        <li><a>Fire an event</a> named <a>start</a> at <var>recorder</var>, then
+        return <code>undefined</code>.</li>
+      </ol>
+      <div class="note">
+        By looking at the content of the tracks when recording start, the User
+        Agent could take frame information into account such as if the video is
+        high or low resolution. If the MediaStreamTrack is a remote track
+        sourced from an RTCPeerConnection, the User Agent is allowed to pick the
+        same codec that the source RTP stream uses, which may allow the User
+        Agent to avoid the cost of re-encoding by recording the raw encoded
+        frames.
+      </div>
+      </li>
 
       <li>If at any point |stream|'s <a>isolation properties</a> change so
       that {{MediaRecorder}} is no longer allowed access to it, the UA MUST


### PR DESCRIPTION
Fixes #139.

This allows the User Agent to avoid the cost of re-encoding.