### PR TITLE
Update "vbr" & "cbr" to "variable" & "constant" per TAG review.

### DIFF
--- a/MediaRecorder.bs
+++ b/MediaRecorder.bs
@@ -125,7 +125,7 @@ interface MediaRecorder : EventTarget {
     then initialize |recorder|'s {{MediaRecorder/audioBitrateMode}} attribute to the value of
     |options|' {{MediaRecorderOptions/audioBitrateMode}} member,
     else initialize |recorder|'s {{MediaRecorder/audioBitrateMode}} attribute to the value
-    "vbr".</li>
+    "variable".</li>
     <li>Return |recorder|.</li>
   </ol></dd>
 </dl>
@@ -530,7 +530,7 @@ dictionary MediaRecorderOptions {
   unsigned long audioBitsPerSecond;
   unsigned long videoBitsPerSecond;
   unsigned long bitsPerSecond;
-  BitrateMode audioBitrateMode = "vbr";
+  BitrateMode audioBitrateMode = "variable";
 };
 </pre>
 
@@ -570,18 +570,18 @@ dictionary MediaRecorderOptions {
 
 <pre class="idl">
 enum BitrateMode {
-  "cbr",
-  "vbr"
+  "constant",
+  "variable"
 };
 </pre>
 
 ### Values ### {#bitratemode-values}
 
 <dl class="domintro">
-  <dt><dfn enum-value for="BitrateMode"><code>cbr</code></dfn></dt>
+  <dt><dfn enum-value for="BitrateMode"><code>constant</code></dfn></dt>
   <dd>Encode at a constant bitrate.</dd>
 
-  <dt><dfn enum-value for="BitrateMode"><code>vbr</code></dfn></dt>
+  <dt><dfn enum-value for="BitrateMode"><code>variable</code></dfn></dt>
   <dd>Encode using a variable bitrate, allowing more space to be used for complex signals
   and less space for less complex signals.</dd>
 </dl>


### PR DESCRIPTION
A request was raised in the [W3C TAG review](https://github.com/w3ctag/design-reviews/issues/540) for https://github.com/w3c/mediacapture-record/pull/185 to change the `BitrateMode` enum values to "constant" and "variable".


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/sizeak/mediacapture-record/pull/210.html" title="Last updated on Dec 16, 2020, 2:53 PM UTC (59f8565)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/mediacapture-record/210/081eda8...sizeak:59f8565.html" title="Last updated on Dec 16, 2020, 2:53 PM UTC (59f8565)">Diff</a>