### PR TITLE
Remove superfluous MediaRecorderErrorEvent interface

### DIFF
--- a/MediaRecorder.bs
+++ b/MediaRecorder.bs
@@ -170,7 +170,7 @@ interface MediaRecorder : EventTarget {
   <dd>Called to handle the <a event>resume</a> event.</dd>
 
   <dt><dfn attribute for="MediaRecorder"><code>onerror</code></dfn></dt>
-  <dd>Called to handle a {{MediaRecorderErrorEvent}}.</dd>
+  <dd>Called to handle an {{ErrorEvent}}.</dd>
 
   <dt><dfn attribute for="MediaRecorder"><code>videoBitsPerSecond</code></dfn></dt>
   <dd>The target bitrate used to encode video tracks.</dd>
@@ -670,7 +670,7 @@ dictionary BlobEventInit {
 
 The UA will throw a {{DOMException}} when the error can be detected at the time
 that the call is made. In all other cases the UA will <a>fire an event</a> named
-{{MediaRecorderErrorEvent}}.  If recording has been started and not yet stopped
+{{ErrorEvent}}.  If recording has been started and not yet stopped
 when the error occurs, let <var>blob</var> be the {{Blob}} of collected data so
 far; after raising the error, the UA will <a data-lt="fire a blob event">fire a
 dataavailable event</a> with <var>blob</var>; immediately after the UA will then
@@ -680,59 +680,20 @@ maximum {{Blob}} size that it will support, or the number of
 {{MediaStreamTrack}}s it will record at once.
 It will signal a fatal error if these limits are exceeded.
 
-## MediaRecorderErrorEvent ## {#errorevent-section}
-
-The {{MediaRecorderErrorEvent}} interface is defined for cases when an event is
-raised that was caused by an error.
+## Error eventsMediaRecorderErrorEvent ## {#errorevent-section}
 
 To <dfn>fire an error event</dfn>
 named <var>e</var> with a {{DOMException}} named <var>error</var> means that an
 event with the name <var>e</var>, which does not bubble (except where otherwise
 stated) and is not cancelable (except where otherwise stated), and which uses
-the {{MediaRecorderErrorEvent}} interface with the
-{{MediaRecorderErrorEvent/error}} attribute set to <var>error</var>, must be
-created and
-<a href="https://dom.spec.whatwg.org/#concept-event-dispatch">dispatched</a> at
+the {{ErrorEvent}} interface with the
+{{ErrorEvent/error}} attribute set to <var>error</var>, must be
+created and [=dispatch|dispatch=] at
 the given target.
 
-<pre class="idl">
-dictionary MediaRecorderErrorEventInit : EventInit {
-  required DOMException error;
-};
-
-[Exposed=Window]
-interface MediaRecorderErrorEvent : Event {
-  constructor(DOMString type, MediaRecorderErrorEventInit eventInitDict);
-  [SameObject] readonly attribute DOMException error;
-};
-</pre>
-
-### Constructors ### {#errorevent-constructor}
-
-<dl class="domintro">
-  <dt><dfn constructor for="MediaRecorderErrorEvent"><code>MediaRecorderErrorEvent(DOMString type, MediaRecorderErrorEventInit eventInitDict)</code></dfn></dt>
-  <dd>
-  Constructs a new {{MediaRecorderErrorEvent}}.
-
-
-  </dd>
-</dl>
-
-### Attributes ### {#errorevent-attributes}
-
-<dl class="domintro">
-  <dt><dfn attribute for="MediaRecorderErrorEvent"><code>error</code></dfn></dt>
-  <dd>The DOMException error that triggered the event.</dd>
-</dl>
-
-### MediaRecorderErrorEventInit ### {#erroreventinit}
-
-<dl class="domintro">
-  <dt><dfn dict-member for="MediaRecorderErrorEventInit"><code>error</code></dfn></dt>
-  <dd>The {{DOMException}} causing the error that triggered the event.
-  An explanatory message about the error circumstances MAY be provided
-  in its <a href="https://heycam.github.io/webidl/#es-DOMException-constructor-object">
-  message</a> attribute.
+The {{DOMException}} causing the error that triggered the event may provide
+an explanatory message about the error circumstances
+in its {{DOMException/message}} attribute.
 
   <div class="note">
   If an implementation places non-standard properties on {{DOMException}},
@@ -740,8 +701,6 @@ interface MediaRecorderErrorEvent : Event {
   point to whichever method call most closely identifies the run-time operation
   that caused the error, e.g. {{start()}}.
   </div>
-  </dd>
-</dl>
 
 ## Exception Summary ## {#exception-summary}
 
@@ -826,7 +785,7 @@ The following additional events fire on {{MediaRecorder}} objects:
     </tr>
     <tr>
       <td><dfn event for=MediaRecorder>error</dfn></td>
-      <td>{{MediaRecorderErrorEvent}}</td>
+      <td>{{ErrorEvent}}</td>
       <td>An error has occurred, e.g. out of memory or a modification to
       the {{MediaRecorder/stream}} has occurred that makes it impossible to
       continue recording (e.g. a Track has been added to or removed from

--- a/MediaRecorder.bs
+++ b/MediaRecorder.bs
@@ -669,8 +669,7 @@ dictionary BlobEventInit {
 <em>This section is non-normative.</em>
 
 The UA will throw a {{DOMException}} when the error can be detected at the time
-that the call is made. In all other cases the UA will <a>fire an event</a> named
-{{ErrorEvent}}.  If recording has been started and not yet stopped
+that the call is made. In all other cases the UA will <a>fire an error event</a>.  If recording has been started and not yet stopped
 when the error occurs, let <var>blob</var> be the {{Blob}} of collected data so
 far; after raising the error, the UA will <a data-lt="fire a blob event">fire a
 dataavailable event</a> with <var>blob</var>; immediately after the UA will then
@@ -680,27 +679,9 @@ maximum {{Blob}} size that it will support, or the number of
 {{MediaStreamTrack}}s it will record at once.
 It will signal a fatal error if these limits are exceeded.
 
-## Error eventsMediaRecorderErrorEvent ## {#errorevent-section}
+## Error events ## {#errorevent-section}
 
-To <dfn>fire an error event</dfn>
-named <var>e</var> with a {{DOMException}} named <var>error</var> means that an
-event with the name <var>e</var>, which does not bubble (except where otherwise
-stated) and is not cancelable (except where otherwise stated), and which uses
-the {{ErrorEvent}} interface with the
-{{ErrorEvent/error}} attribute set to <var>error</var>, must be
-created and [=dispatch|dispatch=] at
-the given target.
-
-The {{DOMException}} causing the error that triggered the event may provide
-an explanatory message about the error circumstances
-in its {{DOMException/message}} attribute.
-
-  <div class="note">
-  If an implementation places non-standard properties on {{DOMException}},
-  exposing e.g. stack traces or error line numbers, these are encouraged to
-  point to whichever method call most closely identifies the run-time operation
-  that caused the error, e.g. {{start()}}.
-  </div>
+To <dfn>fire an error event</dfn> means to [= fire an event =] using {{ErrorEvent}} as <var ignore>eventConstructor</var>.
 
 ## Exception Summary ## {#exception-summary}
 


### PR DESCRIPTION
fixes #211


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/dontcallmedom/mediacapture-record/pull/212.html" title="Last updated on Jan 20, 2022, 9:47 AM UTC (071eeac)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/mediacapture-record/212/3fd1025...dontcallmedom:071eeac.html" title="Last updated on Jan 20, 2022, 9:47 AM UTC (071eeac)">Diff</a>