### PR TITLE
Add keyframe interval support.

### DIFF
--- a/MediaRecorder.bs
+++ b/MediaRecorder.bs
@@ -99,15 +99,15 @@ interface MediaRecorder : EventTarget {
     <li>Let |recorder| have a <dfn>\[[ConstrainedBitsPerSecond]]</dfn> internal
     slot, initialized to the value of |options|'
     {{MediaRecorderOptions/bitsPerSecond}} member if it is present, otherwise
-    <code>undefined</code>.</li>
+    <code>null</code>.</li>
     <li>Let |recorder| have a <dfn>\[[VideoKeyFrameIntervalDuration]]</dfn> internal
     slot, initialized to the value of |options|'
     {{MediaRecorderOptions/videoKeyFrameIntervalDuration}} member if it is present, otherwise
-    <code>undefined</code>.</li>
+    <code>null</code>.</li>
     <li>Let |recorder| have a <dfn>\[[VideoKeyFrameIntervalCount]]</dfn> internal
     slot, initialized to the value of |options|'
     {{MediaRecorderOptions/videoKeyFrameIntervalCount}} member if it is present, otherwise
-    <code>undefined</code>.</li>
+    <code>null</code>.</li>
     <li>Initialize |recorder|'s {{MediaRecorder/stream}} attribute to
     |stream|.</li>
     <li>Initialize |recorder|'s {{MediaRecorder/mimeType}} attribute to the

--- a/MediaRecorder.bs
+++ b/MediaRecorder.bs
@@ -247,11 +247,13 @@ interface MediaRecorder : EventTarget {
 
     <li>Let |videoKeyFrameInterval| be the value of |recorder|'s internal
     [=[[VideoKeyFrameInterval]]=] slot if defined, and configure the video encoder to
-    target key frame generation with the interval. If the value isn't defined, the
-    User Agent will emit key frames as it deems fit for the purpose.
+    target key frame generation with the interval, meaning the User Agent SHOULD
+    encode a key frame on the next frame after this interval has passed since the
+    last key frame. If |videoKeyFrameInterval| isn't defined, the User Agent will
+    emit key frames as it deems fit.
     |videoKeyFrameInterval| is a hint for the video encoder and the actual
     intervals in the recording might be surpassed or not achieved. Note also that
-    encoders might make independent decisions when to emit key frames.</li>
+    encoders will make independent decisions about when to emit key frames.</li>
 
     <li>Constrain the configuration of |recorder| to encode using the
     {{BitrateMode}} specified by the value of |recorder|'s {{MediaRecorder/audioBitrateMode}}

--- a/MediaRecorder.bs
+++ b/MediaRecorder.bs
@@ -98,11 +98,15 @@ interface MediaRecorder : EventTarget {
     member.</li>
     <li>Let |recorder| have a <dfn>\[[ConstrainedBitsPerSecond]]</dfn> internal
     slot, initialized to the value of |options|'
-    {{MediaRecorderOptions/bitsPerSecond}} member, if it is present, otherwise
+    {{MediaRecorderOptions/bitsPerSecond}} member if it is present, otherwise
     <code>undefined</code>.</li>
-    <li>Let |recorder| have a <dfn>\[[VideoKeyFrameInterval]]</dfn> internal
+    <li>Let |recorder| have a <dfn>\[[VideoKeyFrameIntervalDuration]]</dfn> internal
     slot, initialized to the value of |options|'
-    {{MediaRecorderOptions/videoKeyFrameInterval}} member, if it is present, otherwise
+    {{MediaRecorderOptions/videoKeyFrameIntervalDuration}} member if it is present, otherwise
+    <code>undefined</code>.</li>
+    <li>Let |recorder| have a <dfn>\[[VideoKeyFrameIntervalCount]]</dfn> internal
+    slot, initialized to the value of |options|'
+    {{MediaRecorderOptions/videoKeyFrameIntervalCount}} member if it is present, otherwise
     <code>undefined</code>.</li>
     <li>Initialize |recorder|'s {{MediaRecorder/stream}} attribute to
     |stream|.</li>
@@ -245,15 +249,24 @@ interface MediaRecorder : EventTarget {
     the value might be surpassed, not achieved, or only be achieved over a long
     period of time.</li>
 
-    <li>Let |videoKeyFrameInterval| be the value of |recorder|'s internal
-    [=[[VideoKeyFrameInterval]]=] slot if defined, and configure the video encoder to
-    target key frame generation with the interval, meaning the User Agent SHOULD
-    encode a key frame on the next frame after this interval has passed since the
-    last key frame. If |videoKeyFrameInterval| isn't defined, the User Agent will
-    emit key frames as it deems fit.
-    |videoKeyFrameInterval| is a hint for the video encoder and the actual
-    intervals in the recording might be surpassed or not achieved. Note also that
-    encoders will make independent decisions about when to emit key frames.</li>
+    <li>Let |videoKeyFrameIntervalDuration| be the value of |recorder|'s internal
+    [=[[VideoKeyFrameIntervalDuration]]=] slot if defined. Additionally let
+    |videoKeyFrameIntervalCount| be the value of |recorder|'s internal
+    [=[[VideoKeyFrameIntervalCount]]=] slot if defined.
+    If neither of the slots are defined, the User Agent may emit key frames as
+    it deems fit.
+    If only |videoKeyFrameIntervalDuration| is defined, the video encoder
+    SHOULD produce a keyframe on the first frame arriving after
+    |videoKeyFrameIntervalDuration| elapsed since the last key frame.
+    If only |videoKeyFrameIntervalCount| is defined, the video encoder
+    SHOULD produce a keyframe on the first frame arriving after
+    |videoKeyFrameIntervalCount| frames passed since the last key frame.
+    If both are defined, the video encoder SHOULD produce a keyframe on the
+    first frame arriving after both |videoKeyFrameIntervalDuration| elapsed AND
+    |videoKeyFrameIntervalCount| frames passed since the last key frame.
+
+    Note that encoders will sometimes make independent decisions about when to
+    emit key frames.</li>
 
     <li>Constrain the configuration of |recorder| to encode using the
     {{BitrateMode}} specified by the value of |recorder|'s {{MediaRecorder/audioBitrateMode}}
@@ -545,7 +558,8 @@ dictionary MediaRecorderOptions {
   unsigned long videoBitsPerSecond;
   unsigned long bitsPerSecond;
   BitrateMode audioBitrateMode = "variable";
-  DOMHighResTimeStamp videoKeyFrameInterval;
+  DOMHighResTimeStamp videoKeyFrameIntervalDuration;
+  unsigned long videoKeyFrameIntervalCount;
 };
 </pre>
 
@@ -580,9 +594,15 @@ dictionary MediaRecorderOptions {
   <dt><dfn dict-member for="MediaRecorderOptions"><code>audioBitrateMode</code></dfn></dt>
   <dd>Specifes the {{BitrateMode}} that should be used to encode the Audio track(s).</dd>
 
-  <dt><dfn dict-member for="MediaRecorderOptions"><code>videoKeyFrameInterval</code></dfn></dt>
-  <dd>Specifies the nominal interval between key frames in the encoded video stream.
-  If this value isn't specified, the UA will control key frame generation as it sees fit.</dd>
+  <dt><dfn dict-member for="MediaRecorderOptions"><code>videoKeyFrameIntervalDuration</code></dfn></dt>
+  <dd>Specifies the nominal interval in time between key frames in the encoded video stream.
+  The UA controls key frame generation considering this dictionary member as well as 
+  {{MediaRecorderOptions/videoKeyFrameIntervalCount}}.</dd>
+
+  <dt><dfn dict-member for="MediaRecorderOptions"><code>videoKeyFrameIntervalCount</code></dfn></dt>
+  <dd>Specifies the interval in number of frames between key frames in the encoded video stream.
+  The UA controls key frame generation considering this dictionary member as well as 
+  {{MediaRecorderOptions/videoKeyFrameIntervalDuration}}.</dd>
 </dl>
 
 ## BitrateMode ## {#bitratemode}

--- a/MediaRecorder.bs
+++ b/MediaRecorder.bs
@@ -249,10 +249,10 @@ interface MediaRecorder : EventTarget {
     the value might be surpassed, not achieved, or only be achieved over a long
     period of time.</li>
 
-    <li>Let |videoKeyFrameIntervalDuration| be the value of |recorder|'s internal
-    [=[[VideoKeyFrameIntervalDuration]]=] slot if defined, and let
-    |videoKeyFrameIntervalCount| be the value of |recorder|'s internal
-    [=[[VideoKeyFrameIntervalCount]]=] slot if defined. The UA SHOULD constrain the
+    <li>Let |videoKeyFrameIntervalDuration| be
+    |recorder|.[=[[VideoKeyFrameIntervalDuration]]=], and let
+    |videoKeyFrameIntervalCount| be
+    |recorder|.[=[[VideoKeyFrameIntervalCount]]=]. The UA SHOULD constrain the
     configuration of |recorder| so that the video encoders follow the below rules:
 
     <ol>

--- a/MediaRecorder.bs
+++ b/MediaRecorder.bs
@@ -123,7 +123,7 @@ interface MediaRecorder : EventTarget {
     present. Otherwise, choose a target value the User Agent deems reasonable
     for audio.</li>
     <li>If |recorder|'s [=[[ConstrainedBitsPerSecond]]=] slot is not
-    <code>undefined</code>, set |recorder|'s {{MediaRecorder/videoBitsPerSecond}} and
+    <code>null</code>, set |recorder|'s {{MediaRecorder/videoBitsPerSecond}} and
     {{MediaRecorder/audioBitsPerSecond}} attributes to values the User Agent deems reasonable
     for the respective media types, such that the sum of {{MediaRecorder/videoBitsPerSecond}}
     and {{MediaRecorder/audioBitsPerSecond}} is close to the value of |recorder|'s
@@ -228,8 +228,8 @@ interface MediaRecorder : EventTarget {
     media type, container, and codec specified in the [=[[ConstrainedMimeType]]=]
     slot.</li>
 
-    <li>If |recorder|'s [=[[ConstrainedBitsPerSecond]]=] slot is not
-    <code>undefined</code>, set |recorder|'s {{MediaRecorder/videoBitsPerSecond}} and
+    <li>If |recorder|'s [=[[ConstrainedBitsPerSecond]]=] slot is
+    <code>null</code>, set |recorder|'s {{MediaRecorder/videoBitsPerSecond}} and
     {{MediaRecorder/audioBitsPerSecond}} attributes to values the User Agent deems reasonable
     for the respective media types, for recording all tracks in |tracks|, such
     that the sum of {{MediaRecorder/videoBitsPerSecond}} and {{MediaRecorder/audioBitsPerSecond}} is close
@@ -253,24 +253,25 @@ interface MediaRecorder : EventTarget {
     |recorder|.[=[[VideoKeyFrameIntervalDuration]]=], and let
     |videoKeyFrameIntervalCount| be
     |recorder|.[=[[VideoKeyFrameIntervalCount]]=]. The UA SHOULD constrain the
-    configuration of |recorder| so that the video encoders follow the below rules:
+    configuration of |recorder| so that the video encoder follows the below rules:
 
-    <ol>
-    <li>If neither of the slots are defined, the User Agent may emit key frames as
-    it deems fit.</li>
-
-    <li>If only |videoKeyFrameIntervalDuration| is defined, the video encoder
-    produces a keyframe on the first frame arriving after |videoKeyFrameIntervalDuration|
+    <ul>
+    <li>If |videoKeyFrameIntervalDuration| is not <code>null</code> and |videoKeyFrameIntervalCount| is <code>null</code>,
+    the video encoder produces a keyframe on the first frame arriving after |videoKeyFrameIntervalDuration|
     seconds elapsed since the last key frame.</li>
 
-    <li>If only |videoKeyFrameIntervalCount| is defined, the video encoder produces a keyframe
-    on the first frame arriving after |videoKeyFrameIntervalCount| frames passed
-    since the last key frame.</li>
+    <li>If |videoKeyFrameIntervalCount| is not <code>null</code> and |videoKeyFrameIntervalDuration| is <code>null</code>,
+    the video encoder produces a keyframe on the first frame arriving after |videoKeyFrameIntervalCount|
+    frames passed since the last key frame.</li>
 
-    <li>If both are defined, the video encoder produces a keyframe on the first frame arriving after
+    <li>If |videoKeyFrameIntervalDuration| and |videoKeyFrameIntervalCount| are both not <code>null</code>,
+    the video encoder produces a keyframe on the first frame arriving after
     both |videoKeyFrameIntervalDuration| seconds elapsed AND at least |videoKeyFrameIntervalCount|
     frames passed since the last key frame.</li>
-    </ol>
+
+    <li>If both |videoKeyFrameIntervalDuration| and |videoKeyFrameIntervalCount| are <code>null</code>,
+    the User Agent may emit key frames as it deems fit.</li>
+    </ul>
 
     Note that encoders will sometimes make independent decisions about when to
     emit key frames.</li>

--- a/MediaRecorder.bs
+++ b/MediaRecorder.bs
@@ -254,7 +254,6 @@ interface MediaRecorder : EventTarget {
     |videoKeyFrameIntervalCount| be
     |recorder|.[=[[VideoKeyFrameIntervalCount]]=]. The UA SHOULD constrain the
     configuration of |recorder| so that the video encoder follows the below rules:
-
     <ul>
     <li>If |videoKeyFrameIntervalDuration| is not <code>null</code> and |videoKeyFrameIntervalCount| is <code>null</code>,
     the video encoder produces a keyframe on the first frame arriving after |videoKeyFrameIntervalDuration|
@@ -264,10 +263,8 @@ interface MediaRecorder : EventTarget {
     the video encoder produces a keyframe on the first frame arriving after |videoKeyFrameIntervalCount|
     frames passed since the last key frame.</li>
 
-    <li>If |videoKeyFrameIntervalDuration| and |videoKeyFrameIntervalCount| are both not <code>null</code>,
-    the video encoder produces a keyframe on the first frame arriving after
-    both |videoKeyFrameIntervalDuration| seconds elapsed AND at least |videoKeyFrameIntervalCount|
-    frames passed since the last key frame.</li>
+    <li>If both |videoKeyFrameIntervalDuration| and |videoKeyFrameIntervalCount| are not <code>null</code>,
+    the UA may ignore either.</li>
 
     <li>If both |videoKeyFrameIntervalDuration| and |videoKeyFrameIntervalCount| are <code>null</code>,
     the User Agent may emit key frames as it deems fit.</li>

--- a/MediaRecorder.bs
+++ b/MediaRecorder.bs
@@ -250,20 +250,27 @@ interface MediaRecorder : EventTarget {
     period of time.</li>
 
     <li>Let |videoKeyFrameIntervalDuration| be the value of |recorder|'s internal
-    [=[[VideoKeyFrameIntervalDuration]]=] slot if defined. Additionally let
+    [=[[VideoKeyFrameIntervalDuration]]=] slot if defined, and let
     |videoKeyFrameIntervalCount| be the value of |recorder|'s internal
-    [=[[VideoKeyFrameIntervalCount]]=] slot if defined.
-    If neither of the slots are defined, the User Agent may emit key frames as
-    it deems fit.
-    If only |videoKeyFrameIntervalDuration| is defined, the video encoder
-    SHOULD produce a keyframe on the first frame arriving after
-    |videoKeyFrameIntervalDuration| elapsed since the last key frame.
-    If only |videoKeyFrameIntervalCount| is defined, the video encoder
-    SHOULD produce a keyframe on the first frame arriving after
-    |videoKeyFrameIntervalCount| frames passed since the last key frame.
-    If both are defined, the video encoder SHOULD produce a keyframe on the
-    first frame arriving after both |videoKeyFrameIntervalDuration| elapsed AND
-    |videoKeyFrameIntervalCount| frames passed since the last key frame.
+    [=[[VideoKeyFrameIntervalCount]]=] slot if defined. The UA SHOULD constrain the
+    configuration of |recorder| so that the video encoders follow the below rules:
+
+    <ol>
+    <li>If neither of the slots are defined, the User Agent may emit key frames as
+    it deems fit.</li>
+
+    <li>If only |videoKeyFrameIntervalDuration| is defined, the video encoder
+    produces a keyframe on the first frame arriving after |videoKeyFrameIntervalDuration|
+    seconds elapsed since the last key frame.</li>
+
+    <li>If only |videoKeyFrameIntervalCount| is defined, the video encoder produces a keyframe
+    on the first frame arriving after |videoKeyFrameIntervalCount| frames passed
+    since the last key frame.</li>
+
+    <li>If both are defined, the video encoder produces a keyframe on the first frame arriving after
+    both |videoKeyFrameIntervalDuration| seconds elapsed AND at least |videoKeyFrameIntervalCount|
+    frames passed since the last key frame.</li>
+    </ol>
 
     Note that encoders will sometimes make independent decisions about when to
     emit key frames.</li>

--- a/MediaRecorder.bs
+++ b/MediaRecorder.bs
@@ -100,6 +100,10 @@ interface MediaRecorder : EventTarget {
     slot, initialized to the value of |options|'
     {{MediaRecorderOptions/bitsPerSecond}} member, if it is present, otherwise
     <code>undefined</code>.</li>
+    <li>Let |recorder| have a <dfn>\[[VideoKeyFrameInterval]]</dfn> internal
+    slot, initialized to the value of |options|'
+    {{MediaRecorderOptions/videoKeyFrameInterval}} member, if it is present, otherwise
+    <code>undefined</code>.</li>
     <li>Initialize |recorder|'s {{MediaRecorder/stream}} attribute to
     |stream|.</li>
     <li>Initialize |recorder|'s {{MediaRecorder/mimeType}} attribute to the
@@ -240,6 +244,14 @@ interface MediaRecorder : EventTarget {
     |recorder| will be recording. |audioBitrate| is a hint for the encoder and
     the value might be surpassed, not achieved, or only be achieved over a long
     period of time.</li>
+
+    <li>Let |videoKeyFrameInterval| be the value of |recorder|'s internal
+    [=[[VideoKeyFrameInterval]]=] slot if defined, and configure the video encoder to
+    target key frame generation with the interval. If the value isn't defined, the
+    User Agent will emit key frames as it deems fit for the purpose.
+    |videoKeyFrameInterval| is a hint for the video encoder and the actual
+    intervals in the recording might be surpassed or not achieved. Note also that
+    encoders might make independent decisions when to emit key frames.</li>
 
     <li>Constrain the configuration of |recorder| to encode using the
     {{BitrateMode}} specified by the value of |recorder|'s {{MediaRecorder/audioBitrateMode}}
@@ -531,6 +543,7 @@ dictionary MediaRecorderOptions {
   unsigned long videoBitsPerSecond;
   unsigned long bitsPerSecond;
   BitrateMode audioBitrateMode = "variable";
+  DOMHighResTimeStamp videoKeyFrameInterval;
 };
 </pre>
 
@@ -564,6 +577,10 @@ dictionary MediaRecorderOptions {
   
   <dt><dfn dict-member for="MediaRecorderOptions"><code>audioBitrateMode</code></dfn></dt>
   <dd>Specifes the {{BitrateMode}} that should be used to encode the Audio track(s).</dd>
+
+  <dt><dfn dict-member for="MediaRecorderOptions"><code>videoKeyFrameInterval</code></dfn></dt>
+  <dd>Specifies the nominal interval between key frames in the encoded video stream.
+  If this value isn't specified, the UA will control key frame generation as it sees fit.</dd>
 </dl>
 
 ## BitrateMode ## {#bitratemode}

--- a/MediaRecorder.bs
+++ b/MediaRecorder.bs
@@ -257,7 +257,7 @@ interface MediaRecorder : EventTarget {
     <ul>
     <li>If |videoKeyFrameIntervalDuration| is not <code>null</code> and |videoKeyFrameIntervalCount| is <code>null</code>,
     the video encoder produces a keyframe on the first frame arriving after |videoKeyFrameIntervalDuration|
-    seconds elapsed since the last key frame.</li>
+    milliseconds elapsed since the last key frame.</li>
 
     <li>If |videoKeyFrameIntervalCount| is not <code>null</code> and |videoKeyFrameIntervalDuration| is <code>null</code>,
     the video encoder produces a keyframe on the first frame arriving after |videoKeyFrameIntervalCount|

--- a/MediaRecorder.bs
+++ b/MediaRecorder.bs
@@ -228,7 +228,7 @@ interface MediaRecorder : EventTarget {
     media type, container, and codec specified in the [=[[ConstrainedMimeType]]=]
     slot.</li>
 
-    <li>If |recorder|'s [=[[ConstrainedBitsPerSecond]]=] slot is
+    <li>If |recorder|'s [=[[ConstrainedBitsPerSecond]]=] slot is not
     <code>null</code>, set |recorder|'s {{MediaRecorder/videoBitsPerSecond}} and
     {{MediaRecorder/audioBitsPerSecond}} attributes to values the User Agent deems reasonable
     for the respective media types, for recording all tracks in |tracks|, such


### PR DESCRIPTION
This PR adds support for video key frame configurability in the MediaRecorder API.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/handellm/mediacapture-record/pull/216.html" title="Last updated on Apr 20, 2023, 2:08 PM UTC (f6c76cb)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/mediacapture-record/216/c71f537...handellm:f6c76cb.html" title="Last updated on Apr 20, 2023, 2:08 PM UTC (f6c76cb)">Diff</a>