### PR TITLE
Throw NotSupportedError if both videoKeyFrameIntervalDuration and videoKeyFrameIntervalCount are set

### DIFF
--- a/MediaRecorder.bs
+++ b/MediaRecorder.bs
@@ -264,7 +264,7 @@ interface MediaRecorder : EventTarget {
     frames passed since the last key frame.</li>
 
     <li>If both |videoKeyFrameIntervalDuration| and |videoKeyFrameIntervalCount| are not <code>null</code>,
-    the UA may ignore either.</li>
+    then throw a {{NotSupportedError}} {{DOMException}} and abort these steps.</li>
 
     <li>If both |videoKeyFrameIntervalDuration| and |videoKeyFrameIntervalCount| are <code>null</code>,
     the User Agent may emit key frames as it deems fit.</li>


### PR DESCRIPTION
Fixes https://github.com/w3c/mediacapture-record/issues/219


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/youennf/mediacapture-record/pull/220.html" title="Last updated on May 5, 2023, 9:15 AM UTC (cfe2f96)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/mediacapture-record/220/4b57924...youennf:cfe2f96.html" title="Last updated on May 5, 2023, 9:15 AM UTC (cfe2f96)">Diff</a>