### PR TITLE
Update https://w3c.github.io/mediacapture-record/#dom-blobeventinit-timecode.

### DIFF
--- a/MediaRecorder.bs
+++ b/MediaRecorder.bs
@@ -680,10 +680,11 @@ enum RecordingState {
   encoding of the blob data.
 
   <dt><dfn attribute for="BlobEvent"><code>timecode</code></dfn></dt>
-  <dd>The difference between the timestamp of the first chunk in
-  {{BlobEvent/data}} and the timestamp of the first chunk in the first
-  {{BlobEvent}} produced by this recorder as a {{DOMHighResTimeStamp}} [[!HR-TIME]].  Note that the {{BlobEvent/timecode}}
-  in the first produced {{BlobEvent}} does not need to be zero.
+  <dd>For a MediaRecorder instance, the {{BlobEvent/timecode}} in the first
+  produced {{BlobEvent}} contains 0. Subsequent {{BlobEvent}}'s
+  {{BlobEvent/timecode}} contain the difference of the timestamp of creation of
+  the first chunk in said {{BlobEvent}} and the timestamp of the first chunk of the
+  first produced {{BlobEvent}}, as {{DOMHighResTimeStamp}} [[!HR-TIME]].
   </dd>
 
 </dl>

--- a/MediaRecorder.bs
+++ b/MediaRecorder.bs
@@ -681,7 +681,7 @@ enum RecordingState {
 
   <dt><dfn attribute for="BlobEvent"><code>timecode</code></dfn></dt>
   <dd>For a MediaRecorder instance, the {{BlobEvent/timecode}} in the first
-  produced {{BlobEvent}} contains 0. Subsequent {{BlobEvent}}'s
+  produced {{BlobEvent}} MUST contain 0. Subsequent {{BlobEvent}}'s
   {{BlobEvent/timecode}} contain the difference of the timestamp of creation of
   the first chunk in said {{BlobEvent}} and the timestamp of the first chunk of the
   first produced {{BlobEvent}}, as {{DOMHighResTimeStamp}} [[!HR-TIME]].


### PR DESCRIPTION
The spec text was unclear. From offline discussion with the original spec author it's believed that the initial intent of the spec language was meant to convey that the first produced timecode would contain an absolute timestamp. However, it's not clear what use case is unlocked by that, as the user can construct their own absolute timestamp with performance.now() on event reception. This ignores the fact that the event handler can execute delayed, but since it's not clear what problem this fixes, this PR simply makes the timestamp sequence start with zero instead.

Fixes #222.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/handellm/mediacapture-record/pull/223.html" title="Last updated on Sep 26, 2024, 2:03 PM UTC (5cf4f29)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/mediacapture-record/223/48e2abf...handellm:5cf4f29.html" title="Last updated on Sep 26, 2024, 2:03 PM UTC (5cf4f29)">Diff</a>