### PR TITLE
Deprecate MediaRecorder.isTypeSupported() by limiting it to fixed list of identifiers w/wildcards

### DIFF
--- a/MediaRecorder.bs
+++ b/MediaRecorder.bs
@@ -523,11 +523,12 @@ interface MediaRecorder : EventTarget {
   This method is deprecated; it exists for legacy compatibility reasons only.
   The <dfn>list of synchronously exposed codec specifiers</dfn> are:
   <code>"vp8"</code>, <code>"vp9"</code>, <code>"h264"</code> aka
-  <code>"avc1"</code>, <code>"av01"</code>, and <code>"opus"</code>.
+  <code>"avc1"</code>, <code>"av1"</code> aka <code>"av01"</code>, and
+  <code>"opus"</code>.
   <div class="note" highlight="javascript">
     Due to the difficulty of detecting hardware support synchronously,
     precise answers can be timing dependent.
-    For example <code>"av01"</code> is synchronously exposed whereas
+    For example: <code>"av01"</code> is synchronously exposed whereas
     <code>"av01.0.19M.08"</code> is not. Users are expected to discover
     specific profile levels and newer codecs through {{MediaCapabilities}}
     instead:

--- a/MediaRecorder.bs
+++ b/MediaRecorder.bs
@@ -524,6 +524,8 @@ interface MediaRecorder : EventTarget {
   The <dfn>list of synchronously exposed codecs</dfn> is: <code>vp8</code>,
   <code>vp9</code>, <code>h264</code>, and <code>opus</code>.
   <div class="note" highlight="javascript">
+    Due to the difficulty of detecting hardware support synchronously, precise
+    answers may be timing dependent.
     Users are expected to discover newer codecs through {{MediaCapabilities}} instead.
     For example:
     <pre>

--- a/MediaRecorder.bs
+++ b/MediaRecorder.bs
@@ -89,8 +89,8 @@ interface MediaRecorder : EventTarget {
   <ol>
     <li>Let |stream| be the constructor's first argument.</li>
     <li>Let |options| be the constructor's second argument.</li>
-    <li>If invoking [$is type supported$] with |options|'
-    {{MediaRecorderOptions/mimeType}} member as its argument returns false,
+    <li>Let |type| be |options|' {{MediaRecorderOptions/mimeType}}.
+    <li>If invoking [$is type supported$] with |type| and the value true returns false,
     throw a {{NotSupportedError}} {{DOMException}} and abort these steps.</li>
     <li>Let |recorder| be a newly constructed {{MediaRecorder}} object.</li>
     <li>Let |recorder| have a <dfn>\[[ConstrainedMimeType]]</dfn> internal slot,
@@ -299,6 +299,17 @@ interface MediaRecorder : EventTarget {
         while recording, the User Agent has to be prepared to re-encode it to
         avoid interruptions.
       </div>
+      <li>If the User Agent does not support the specified combination of media
+      type/subtype, codecs and container, then it MUST abort the remaining
+      steps and queue a task, using the DOM manipulation task source, that runs
+      the following steps:
+      <ol>
+        <li>[$Inactivate the recorder$] with |recorder|.</li>
+        <li><a>Fire an error event</a> named {{NotSupportedError}} at
+        <var>recorder</var>.</li>
+        <li><a>Fire an event</a> named <a event>stop</a> at <var>recorder</var>.</li>
+      </ol>
+      </li>
       </li>
       <li>Start recording all tracks in |tracks| using the |recorder|'s current
       configuration and gather the data into a {{Blob}} <var>blob</var>. Queue a
@@ -510,18 +521,39 @@ interface MediaRecorder : EventTarget {
   <dt><dfn method for="MediaRecorder"><code>isTypeSupported(DOMString type)
     </code></dfn></dt>
   <dd>
+  This method is deprecated; it exists for legacy compatibility reasons only.
+  The <dfn>list of synchronously exposed codecs</dfn> is: <code>vp8</code>,
+  <code>vp9</code>, <code>h264</code>, and <code>opus</code>.
+  <div class="note" highlight="javascript">
+    Users are expected to discover newer codecs through {{MediaCapabilities}} instead.
+    For example:
+    <pre>
+    await navigator.mediaCapabilities.encodingInfo({
+      type: "record",
+      video: {
+        contentType: "video/webm;codecs=av01",
+        width: 1920,
+        height: 1080,
+        bitrate: 120000,
+        framerate: 48,
+      }
+    });
+    </pre>
+  </div>
+  </dd>
+  <dd>
   Check to see whether a {{MediaRecorder}} can record in a specified MIME type.
   If true is returned from this method, it only indicates that the
   {{MediaRecorder}} implementation is capable of recording {{Blob}} objects for
   the specified MIME type. Recording may still fail if sufficient resources are
   not available to support the concrete media encoding. When this method is
   invoked, the User Agent must return the result of [$is type supported$],
-  given the method's first argument.
+  with the method's first argument and the value false.
   </dd>
   <dd algorithm="is type supported">The <dfn abstract-op>is type supported</dfn>
-  algorithm consists of the following steps.
+  algorithm, given a |type| and a boolean |deferNewerCodecsCheck|, consists of
+  the following steps.
   <ol>
-    <li>Let |type| be the algorithm's argument.</li>
     <li>If |type| is an empty string, then return true (note that this case is
     essentially equivalent to leaving up to the UA the choice of both container
     and codecs).</li>
@@ -533,8 +565,14 @@ interface MediaRecorder : EventTarget {
     support, then return false.</li>
     <li>If |type| contains more than one audio codec, or more than one video
     codec, then return false.</li>
-    <li>If |type| contains a codec that the MediaRecorder does not support, then
+    <li>If |type| contains a codec that the MediaRecorder does not support, and
+    that codec  is in the [=list of synchronously exposed codecs=], then
     return false.</li>
+    <li>If the MediaRecorder does not support the specified combination of media
+    type/subtype, and container then return false.</li>
+    <li>If |type| contains a codec that is not in the
+    [=list of synchronously exposed codecs=] and |deferNewerCodecsCheck| is true,
+    then return true.</li>
     <li>If the MediaRecorder does not support the specified combination of media
     type/subtype, codecs and container then return false.</li>
     <li>Return true.</li>

--- a/MediaRecorder.bs
+++ b/MediaRecorder.bs
@@ -521,17 +521,21 @@ interface MediaRecorder : EventTarget {
     </code></dfn></dt>
   <dd>
   This method is deprecated; it exists for legacy compatibility reasons only.
-  The <dfn>list of synchronously exposed codecs</dfn> is: <code>vp8</code>,
-  <code>vp9</code>, <code>h264</code>, and <code>opus</code>.
+  The <dfn>list of synchronously exposed codec specifiers</dfn> are:
+  <code>"vp8"</code>, <code>"vp9"</code>, <code>"h264"</code> aka
+  <code>"avc1"</code>, <code>"av01"</code>, and <code>"opus"</code>.
   <div class="note" highlight="javascript">
     Due to the difficulty of detecting hardware support synchronously,
-    precise answers may be timing dependent. Users are expected to discover
-    newer codecs through {{MediaCapabilities}} instead. For example:
+    precise answers can be timing dependent.
+    For example <code>"av01"</code> is synchronously exposed whereas
+    <code>"av01.0.19M.08"</code> is not. Users are expected to discover
+    specific profile levels and newer codecs through {{MediaCapabilities}}
+    instead:
     <pre>
     await navigator.mediaCapabilities.encodingInfo({
       type: "record",
       video: {
-        contentType: "video/webm;codecs=av01",
+        contentType: "video/webm;codecs=av01.0.19M.08",
         width: 1920,
         height: 1080,
         bitrate: 120000,
@@ -566,13 +570,16 @@ interface MediaRecorder : EventTarget {
     <li>If |type| contains more than one audio codec, or more than one video
     codec, then return false.</li>
     <li>If |type| contains a codec that the MediaRecorder does not support, and
-    that codec  is in the [=list of synchronously exposed codecs=], then
-    return false.</li>
+    that standalone or comma-separated codec specifier string in its entirety is
+    a case-insensitive exact match for an item in the
+    [=list of synchronously exposed codec specifiers=], then return false.
+    </li>
     <li>If the MediaRecorder does not support the specified combination of media
     type/subtype, and container then return false.</li>
-    <li>If |type| contains a codec that is not in the
-    [=list of synchronously exposed codecs=] and |deferNewerCodecsCheck| is true,
-    then return true.</li>
+    <li>If |type| contains a standalone or comma-separated codec specifier string
+    that in its entirety is <em>not</em> a case-insensitive exact match for any
+    item in the [=list of synchronously exposed codec specifiers=] and
+    |deferNewerCodecsCheck| is true, then return true.</li>
     <li>If the MediaRecorder does not support the specified combination of media
     type/subtype, codecs and container then return false.</li>
     <li>Return true.</li>

--- a/MediaRecorder.bs
+++ b/MediaRecorder.bs
@@ -521,10 +521,10 @@ interface MediaRecorder : EventTarget {
     </code></dfn></dt>
   <dd>
   This method is deprecated; it exists for legacy compatibility reasons only.
-  The <dfn>list of synchronously exposed codec specifiers</dfn> are:
+  The <dfn>list of synchronously exposed codec specifiers</dfn> is:
   <code>"vp8"</code>, <code>"vp9"</code>, <code>"h264"</code> aka
-  <code>"avc1"</code>, <code>"av1"</code> aka <code>"av01"</code>, and
-  <code>"opus"</code>.
+  <code>"avc1"</code>, <code>"av1"</code> aka <code>"av01"</code>,
+  <code>"opus"</code>, and <code>"pcm"</code>.
   <div class="note" highlight="javascript">
     Due to the difficulty of detecting hardware support synchronously,
     precise answers can be timing dependent.

--- a/MediaRecorder.bs
+++ b/MediaRecorder.bs
@@ -524,10 +524,9 @@ interface MediaRecorder : EventTarget {
   The <dfn>list of synchronously exposed codecs</dfn> is: <code>vp8</code>,
   <code>vp9</code>, <code>h264</code>, and <code>opus</code>.
   <div class="note" highlight="javascript">
-    Due to the difficulty of detecting hardware support synchronously, precise
-    answers may be timing dependent.
-    Users are expected to discover newer codecs through {{MediaCapabilities}} instead.
-    For example:
+    Due to the difficulty of detecting hardware support synchronously,
+    precise answers may be timing dependent. Users are expected to discover
+    newer codecs through {{MediaCapabilities}} instead. For example:
     <pre>
     await navigator.mediaCapabilities.encodingInfo({
       type: "record",

--- a/MediaRecorder.bs
+++ b/MediaRecorder.bs
@@ -89,7 +89,7 @@ interface MediaRecorder : EventTarget {
   <ol>
     <li>Let |stream| be the constructor's first argument.</li>
     <li>Let |options| be the constructor's second argument.</li>
-    <li>Let |type| be |options|' {{MediaRecorderOptions/mimeType}}.
+    <li>Let |type| be |options|' {{MediaRecorderOptions/mimeType}}.</li>
     <li>If invoking [$is type supported$] with |type| and the value true returns false,
     throw a {{NotSupportedError}} {{DOMException}} and abort these steps.</li>
     <li>Let |recorder| be a newly constructed {{MediaRecorder}} object.</li>
@@ -288,7 +288,7 @@ interface MediaRecorder : EventTarget {
       fully specified, the User Agent specifies them in |recorder|'s current
       configuration. The User Agent MAY take the sources of the tracks in
       |tracks| into account when deciding which container and codecs to
-      use.
+      use.</li>
       <div class="note">
         By looking at the sources of the tracks in |tracks| when recording
         starts, the User Agent could choose a configuration that avoids
@@ -309,7 +309,6 @@ interface MediaRecorder : EventTarget {
         <var>recorder</var>.</li>
         <li><a>Fire an event</a> named <a event>stop</a> at <var>recorder</var>.</li>
       </ol>
-      </li>
       </li>
       <li>Start recording all tracks in |tracks| using the |recorder|'s current
       configuration and gather the data into a {{Blob}} <var>blob</var>. Queue a

--- a/MediaRecorder.bs
+++ b/MediaRecorder.bs
@@ -536,6 +536,10 @@ interface MediaRecorder : EventTarget {
       type: "record",
       video: {
         contentType: "video/webm;codecs=av01.0.19M.08",
+        width: 640,
+        height: 480,
+        framerate: 30,
+        bitrate: 120000,
       }
     });
     </pre>

--- a/MediaRecorder.bs
+++ b/MediaRecorder.bs
@@ -539,7 +539,7 @@ interface MediaRecorder : EventTarget {
         width: 640,
         height: 480,
         framerate: 30,
-        bitrate: 120000,
+        bitrate: 300000,
       }
     });
     </pre>

--- a/MediaRecorder.bs
+++ b/MediaRecorder.bs
@@ -524,7 +524,7 @@ interface MediaRecorder : EventTarget {
   The <dfn>list of synchronously exposed codec identifiers</dfn> is:
   <code>"vp8"</code>, <code>"vp9"</code>, <code>"h264"</code> aka
   <code>"avc1"</code>, <code>"av1"</code> aka <code>"av01"</code>,
-  <code>hvc1</code>, <code>hev1</code>, <code>avc1</code>, <code>avc3</code>,
+  <code>"hvc1"</code>, <code>"hev1"</code>, <code>"avc1"</code>, <code>"avc3"</code>,
   <code>"opus"</code>, and <code>"pcm"</code>.
   <div class="note" highlight="javascript">
     Due to the difficulty of detecting hardware support synchronously,
@@ -532,14 +532,10 @@ interface MediaRecorder : EventTarget {
     specific profile levels and newer codecs through {{MediaCapabilities}}
     instead:
     <pre>
-    await navigator.mediaCapabilities.encodingInfo({
+    const {supported} = await navigator.mediaCapabilities.encodingInfo({
       type: "record",
       video: {
         contentType: "video/webm;codecs=av01.0.19M.08",
-        width: 1920,
-        height: 1080,
-        bitrate: 120000,
-        framerate: 48,
       }
     });
     </pre>

--- a/MediaRecorder.bs
+++ b/MediaRecorder.bs
@@ -521,15 +521,14 @@ interface MediaRecorder : EventTarget {
     </code></dfn></dt>
   <dd>
   This method is deprecated; it exists for legacy compatibility reasons only.
-  The <dfn>list of synchronously exposed codec specifiers</dfn> is:
+  The <dfn>list of synchronously exposed codec identifiers</dfn> is:
   <code>"vp8"</code>, <code>"vp9"</code>, <code>"h264"</code> aka
   <code>"avc1"</code>, <code>"av1"</code> aka <code>"av01"</code>,
+  <code>hvc1</code> aka <code>hev1</code>, <code>avc1</code> aka <code>avc3</code>,
   <code>"opus"</code>, and <code>"pcm"</code>.
   <div class="note" highlight="javascript">
     Due to the difficulty of detecting hardware support synchronously,
-    precise answers can be timing dependent.
-    For example: <code>"av01"</code> is synchronously exposed whereas
-    <code>"av01.0.19M.08"</code> is not. Users are expected to discover
+    precise answers can be timing dependent. Users are expected to discover
     specific profile levels and newer codecs through {{MediaCapabilities}}
     instead:
     <pre>
@@ -562,28 +561,45 @@ interface MediaRecorder : EventTarget {
     <li>If |type| is an empty string, then return true (note that this case is
     essentially equivalent to leaving up to the UA the choice of both container
     and codecs).</li>
-    <li>If |type| does not contain a valid MIME type string, then return false.
+    <li>If |type| is not a valid MIME type string, then return false.
     </li>
-    <li>If |type| contains a media type or media subtype that the MediaRecorder
-    does not support, then return false.</li>
-    <li>If |type| contains a media container that the MediaRecorder does not
-    support, then return false.</li>
-    <li>If |type| contains more than one audio codec, or more than one video
-    codec, then return false.</li>
-    <li>If |type| contains a codec that the MediaRecorder does not support, and
-    that standalone or comma-separated codec specifier string in its entirety is
-    a case-insensitive exact match for an item in the
-    [=list of synchronously exposed codec specifiers=], then return false.
+    <li>If the MediaRecorder does not support the combination of media
+    type/subtype, and container specified in |type| then return false.</li>
+    <li>Let |codecStrings| be the [=list=] result of [=strictly splitting=] on
+    <code>","</code> the string after <code>codecs=</code> if present in |type|,
+    or an empty [=list=] otherwise.
+    <li>If |codecStrings| contains more than one audio codec or more than one
+    video codec, then return false.</li>
+    <li>Let |codecIdentifiers| be an empty [=list=].</li>
+    <li>For each |codecString| in |codecStrings|, run the following steps:
+      <ol>
+        <li>Let |codecIdentifier| be the [=ASCII lowercase=] of the first part
+          of [=strictly splitting=] |codecString| on <code>"."</code>.</li>
+        <li>[=list/Append=] |codecIdentifier| to |codecIdentifiers|.</li>
+      </ol>
+      <div class="note">
+        The remainder of this algorithm only tests against the identifier
+        part of the codec specifier (e.g. <code>"av01"</code>), ignoring
+        any part after a period (e.g. <code>"av01.0.19M.08"</code>).
+      </div>
     </li>
-    <li>If the MediaRecorder does not support the specified combination of media
-    type/subtype, and container then return false.</li>
-    <li>If |type| contains a standalone or comma-separated codec specifier string
-    that in its entirety is <em>not</em> a case-insensitive exact match for any
-    item in the [=list of synchronously exposed codec specifiers=] and
-    |deferNewerCodecsCheck| is true, then return true.</li>
-    <li>If the MediaRecorder does not support the specified combination of media
-    type/subtype, codecs and container then return false.</li>
+    <li>For each |codecIdentifier| in |codecIdentifiers| that [$is synchronously exposed$], run the following step:
+      <ol>
+        <li>If the MediaRecorder does not support |codecIdentifier| in combination
+          with the media type/subtype and container specified in |type|, then return false.
+        </li>
+      </ol>
+    </li>
+    <li>If any |codecIdentifier| in |codecIdentifiers| is not [$is synchronously exposed|synchronously exposed$], then return |deferNewerCodecsCheck|.</li>
     <li>Return true.</li>
+  </ol>
+  </dd>
+  <dd algorithm="is synchronously exposed">The <dfn abstract-op>is synchronously exposed</dfn>
+  algorithm, given a |codecIdentifier|, consists of
+  the following steps:
+  <ol>
+    <li>Return true if any item in the [=list of synchronously exposed codec identifiers=]
+      is an exact match for |codecIdentifier|, otherwise false.</li>
   </ol>
   </dd>
 </dl>
@@ -1033,4 +1049,5 @@ urlPrefix: https://www.w3.org/TR/fingerprinting-guidance/#
 spec:mediacapture-streams; type:enum-value; text:ended
 spec:mediacapture-streams; type:attribute; text:muted
 spec:mediacapture-streams; type:attribute; text:enabled
+spec:infra; type:dfn; text:list
 </pre>

--- a/MediaRecorder.bs
+++ b/MediaRecorder.bs
@@ -524,7 +524,7 @@ interface MediaRecorder : EventTarget {
   The <dfn>list of synchronously exposed codec identifiers</dfn> is:
   <code>"vp8"</code>, <code>"vp9"</code>, <code>"h264"</code> aka
   <code>"avc1"</code>, <code>"av1"</code> aka <code>"av01"</code>,
-  <code>hvc1</code> aka <code>hev1</code>, <code>avc1</code> aka <code>avc3</code>,
+  <code>hvc1</code> aka <code>hev1</code>, <code>avc1</code>, <code>avc3</code>,
   <code>"opus"</code>, and <code>"pcm"</code>.
   <div class="note" highlight="javascript">
     Due to the difficulty of detecting hardware support synchronously,

--- a/MediaRecorder.bs
+++ b/MediaRecorder.bs
@@ -524,7 +524,7 @@ interface MediaRecorder : EventTarget {
   The <dfn>list of synchronously exposed codec identifiers</dfn> is:
   <code>"vp8"</code>, <code>"vp9"</code>, <code>"h264"</code> aka
   <code>"avc1"</code>, <code>"av1"</code> aka <code>"av01"</code>,
-  <code>hvc1</code> aka <code>hev1</code>, <code>avc1</code>, <code>avc3</code>,
+  <code>hvc1</code>, <code>hev1</code>, <code>avc1</code>, <code>avc3</code>,
   <code>"opus"</code>, and <code>"pcm"</code>.
   <div class="note" highlight="javascript">
     Due to the difficulty of detecting hardware support synchronously,


### PR DESCRIPTION
Fixes #202.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/jan-ivar/mediacapture-record/pull/226.html" title="Last updated on Jan 8, 2026, 1:44 AM UTC (9a476aa)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/mediacapture-record/226/ab24705...jan-ivar:9a476aa.html" title="Last updated on Jan 8, 2026, 1:44 AM UTC (9a476aa)">Diff</a>