### PR TITLE
Made BlobEventInit inherit from EventInit

### DIFF
--- a/MediaRecorder.bs
+++ b/MediaRecorder.bs
@@ -692,7 +692,7 @@ enum RecordingState {
 ## BlobEventInit ## {#blobeventinit}
 
 <pre class="idl">
-dictionary BlobEventInit {
+dictionary BlobEventInit : EventInit {
   required Blob data;
   DOMHighResTimeStamp timecode;
 };


### PR DESCRIPTION
See https://github.com/w3c/mediacapture-record/issues/227 for discussions about the change.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/TB-StarcMed/mediacapture-record/pull/228.html" title="Last updated on Apr 16, 2025, 9:46 AM UTC (3f44e86)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/mediacapture-record/228/ab24705...TB-StarcMed:3f44e86.html" title="Last updated on Apr 16, 2025, 9:46 AM UTC (3f44e86)">Diff</a>